### PR TITLE
[Feat/#14] 관리자 대시보드 API 연동 (Admin)

### DIFF
--- a/src/pages/admin/dashboard/dashboard.tsx
+++ b/src/pages/admin/dashboard/dashboard.tsx
@@ -1,8 +1,8 @@
 import AccessStatusChartSection from '@components/admin/access-status/access-status-chart-section';
 import NoticeSectionContainer from '@components/admin/notice/notice-section-container';
-import { useNavigate } from 'react-router-dom';
 import AdminProfileCard from '@components/admin/profile-card/profile-card';
 import ProductSectionContainer from '@components/product-section/product-section-container';
+import { useNavigate } from 'react-router-dom';
 
 const AdminDashboard = () => {
   const navigate = useNavigate();
@@ -13,7 +13,7 @@ const AdminDashboard = () => {
       <AccessStatusChartSection />
       <NoticeSectionContainer
         onClickAll={() => {
-          navigate(`/admin/notices`);
+          navigate('/admin/notices');
         }}
         onClickNotice={(noticeId) => {
           navigate(`/admin/notices/${noticeId}`);
@@ -21,13 +21,10 @@ const AdminDashboard = () => {
       />
       <ProductSectionContainer
         onClickAll={() => {
-          console.log('전체 상품 보기');
-        }}
-        onClickArrow={() => {
-          console.log('다음 상품 보기');
+          navigate('/admin/products');
         }}
         onClickProduct={(product) => {
-          console.log('상품 클릭', product);
+          navigate(`/admin/products/${product.id}`);
         }}
       />
     </div>

--- a/src/pages/public/home.tsx
+++ b/src/pages/public/home.tsx
@@ -1,3 +1,5 @@
+import { useRecordHits } from '@apis/telegro';
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import headsetImage from '../../assets/images/Landing/headset.svg';
 import productImage1 from '../../assets/images/Landing/image1.png';
@@ -7,6 +9,8 @@ import productImage4 from '../../assets/images/Landing/image4.png';
 
 const productPath = '/products';
 const noticePath = '/notices';
+const HOME_HIT_GUARD_KEY = 'public-home-hit-recorded-at';
+const HOME_HIT_GUARD_MS = 1500;
 
 const floatingLinks = [
   {
@@ -104,6 +108,23 @@ const productCards = [
 const marqueeCards = [...productCards, ...productCards];
 
 const PublicHome = () => {
+  const { mutate: recordHits } = useRecordHits();
+
+  useEffect(() => {
+    const now = Date.now();
+    const lastRecordedAt = Number(sessionStorage.getItem(HOME_HIT_GUARD_KEY));
+
+    if (
+      Number.isFinite(lastRecordedAt) &&
+      now - lastRecordedAt < HOME_HIT_GUARD_MS
+    ) {
+      return;
+    }
+
+    sessionStorage.setItem(HOME_HIT_GUARD_KEY, String(now));
+    recordHits();
+  }, [recordHits]);
+
   return (
     <>
       <section className="relative flex items-center justify-center overflow-x-clip overflow-y-visible px-6 pt-6 pb-28 md:min-h-[60rem] md:px-12 md:pt-8 lg:px-16 lg:pt-4">

--- a/src/shared/components/admin/access-status/access-status-chart-view.tsx
+++ b/src/shared/components/admin/access-status/access-status-chart-view.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useRef, type RefObject } from 'react';
-import { cn } from '@libs/cn';
+import ActionSelectButton from '@components/admin/access-status/action-select-button';
+import AccessStatusGraph from '@components/admin/access-status/access-status-graph';
+import DropdownMenu from '@components/admin/access-status/dropdown-menu';
+import MonthPickerPopover from '@components/admin/access-status/month-picker-popover';
+import YearPickerPopover from '@components/admin/access-status/year-picker-popover';
 import {
   FILTER_OPTIONS,
   useAccessStatusChart,
 } from '@hooks/use-access-status-chart';
-import ActionSelectButton from '@components/admin/access-status/action-select-button';
-import DropdownMenu from '@components/admin/access-status/dropdown-menu';
-import AccessStatusGraph from '@components/admin/access-status/access-status-graph';
-import MonthPickerPopover from '@components/admin/access-status/month-picker-popover';
-import YearPickerPopover from '@components/admin/access-status/year-picker-popover';
+import { cn } from '@libs/cn';
+import { useEffect, useRef, type RefObject } from 'react';
 
 type AccessStatusChartViewProps = ReturnType<typeof useAccessStatusChart>;
 
@@ -52,6 +52,8 @@ const AccessStatusChartSectionView = ({
   activeFilterLabel,
   activeMonthLabel,
   activeYearLabel,
+  isLoading,
+  isError,
   goToPrevPage,
   goToNextPage,
 }: AccessStatusChartViewProps) => {
@@ -85,11 +87,13 @@ const AccessStatusChartSectionView = ({
     >
       <div className="mb-4 flex gap-4 md:mb-6 md:flex-row md:items-center md:justify-between">
         <h2 className="text-[1.75rem] leading-none font-semibold tracking-[-0.02em] text-[#1A1E22] md:text-[2rem]">
-          접속 현황
+          {'\uC811\uC18D \uD604\uD669'}
         </h2>
 
         <div className="relative flex flex-wrap items-center justify-end gap-2 md:gap-3">
-          {filter === 'daily' && (
+          {(filter === 'daily' ||
+            filter === 'weekday' ||
+            filter === 'company') && (
             <div ref={monthPickerRef} className="relative">
               <ActionSelectButton
                 label={activeMonthLabel}
@@ -164,22 +168,36 @@ const AccessStatusChartSectionView = ({
           </div>
 
           <strong className="text-[1.9rem] leading-none font-semibold tracking-[-0.03em] text-[#FFB800] md:text-[2.15rem]">
-            {dataset.totalCount}회
+            {isLoading ? '...' : `${dataset.totalCount}\uD68C`}
           </strong>
         </div>
       </div>
 
-      <AccessStatusGraph
-        filter={filter}
-        data={dataset.data}
-        hovered={hovered}
-        onHoverChange={setHovered}
-        isReady={isReady}
-        canGoPrev={dataset.canGoPrev}
-        canGoNext={dataset.canGoNext}
-        onPrev={goToPrevPage}
-        onNext={goToNextPage}
-      />
+      {isError ? (
+        <div className="flex min-h-[27rem] items-center justify-center text-[1.6rem] text-red-500">
+          {'\uC811\uC18D \uD1B5\uACC4\uB97C \uBD88\uB7EC\uC624\uC9C0 \uBABB\uD588\uC2B5\uB2C8\uB2E4.'}
+        </div>
+      ) : isLoading ? (
+        <div className="flex min-h-[27rem] items-center justify-center text-[1.6rem] text-gray-500">
+          {'\uC811\uC18D \uD1B5\uACC4\uB97C \uBD88\uB7EC\uC624\uB294 \uC911\uC785\uB2C8\uB2E4.'}
+        </div>
+      ) : dataset.data.length === 0 ? (
+        <div className="flex min-h-[27rem] items-center justify-center text-[1.6rem] text-gray-500">
+          {'\uD45C\uC2DC\uD560 \uC811\uC18D \uD1B5\uACC4\uAC00 \uC5C6\uC2B5\uB2C8\uB2E4.'}
+        </div>
+      ) : (
+        <AccessStatusGraph
+          filter={filter}
+          data={dataset.data}
+          hovered={hovered}
+          onHoverChange={setHovered}
+          isReady={isReady}
+          canGoPrev={dataset.canGoPrev}
+          canGoNext={dataset.canGoNext}
+          onPrev={goToPrevPage}
+          onNext={goToNextPage}
+        />
+      )}
     </section>
   );
 };

--- a/src/shared/components/admin/notice/notice-section-container.tsx
+++ b/src/shared/components/admin/notice/notice-section-container.tsx
@@ -18,6 +18,8 @@ export default function NoticeSectionContainer({
     title,
     actionLabel,
     notices: resolvedNotices,
+    isLoading,
+    isError,
     handleClickAll,
   } = useNoticeSection({
     notices,
@@ -29,6 +31,8 @@ export default function NoticeSectionContainer({
       title={title}
       actionLabel={actionLabel}
       notices={resolvedNotices}
+      isLoading={isLoading}
+      isError={isError}
       onClickAll={handleClickAll}
       onClickNotice={onClickNotice}
     />

--- a/src/shared/components/admin/notice/notice-section-view.tsx
+++ b/src/shared/components/admin/notice/notice-section-view.tsx
@@ -5,6 +5,8 @@ type NoticeSectionViewProps = {
   title: string;
   actionLabel: string;
   notices: NoticeItem[];
+  isLoading: boolean;
+  isError: boolean;
   onClickAll: () => void;
   onClickNotice?: (noticeId: number) => void;
 };
@@ -13,6 +15,8 @@ const NoticeSectionView = ({
   title,
   actionLabel,
   notices,
+  isLoading,
+  isError,
   onClickAll,
   onClickNotice,
 }: NoticeSectionViewProps) => {
@@ -30,15 +34,29 @@ const NoticeSectionView = ({
         </button>
       </header>
 
-      <div className="flex-col gap-4">
-        {notices.map((notice) => (
-          <NoticeCard
-            key={notice.id}
-            notice={notice}
-            onClick={onClickNotice}
-          />
-        ))}
-      </div>
+      {isLoading ? (
+        <div className="rounded-2xl bg-white px-[2.2rem] py-[2rem] text-[1.6rem] text-gray-500">
+          {'\uACF5\uC9C0\uC0AC\uD56D\uC744 \uBD88\uB7EC\uC624\uB294 \uC911\uC785\uB2C8\uB2E4.'}
+        </div>
+      ) : isError ? (
+        <div className="rounded-2xl bg-white px-[2.2rem] py-[2rem] text-[1.6rem] text-red-500">
+          {'\uACF5\uC9C0\uC0AC\uD56D\uC744 \uBD88\uB7EC\uC624\uC9C0 \uBABB\uD588\uC2B5\uB2C8\uB2E4.'}
+        </div>
+      ) : notices.length ? (
+        <div className="flex-col gap-4">
+          {notices.map((notice) => (
+            <NoticeCard
+              key={notice.id}
+              notice={notice}
+              onClick={onClickNotice}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-2xl bg-white px-[2.2rem] py-[2rem] text-[1.6rem] text-gray-500">
+          {'\uD45C\uC2DC\uD560 \uACF5\uC9C0\uC0AC\uD56D\uC774 \uC5C6\uC2B5\uB2C8\uB2E4.'}
+        </div>
+      )}
     </section>
   );
 };

--- a/src/shared/components/product-section/product-card.tsx
+++ b/src/shared/components/product-section/product-card.tsx
@@ -12,7 +12,7 @@ export default function ProductCard({ product, onClick }: ProductCardProps) {
       <button
         type="button"
         onClick={() => onClick?.(product)}
-        className="group relative block overflow-hidden rounded-[1.913rem] text-left"
+        className="group relative block cursor-pointer overflow-hidden rounded-[1.913rem] text-left"
       >
         <img
           src={product.imageSrc}
@@ -29,21 +29,17 @@ export default function ProductCard({ product, onClick }: ProductCardProps) {
 
       <div className="flex items-center justify-between px-[1rem]">
         <div className="flex w-[22.3rem] flex-col items-start gap-[1rem]">
-          <p className="w-full text-[2.5rem] leading-[1.3] font-semibold text-black">
-            {product.title}
-          </p>
-          <p className="w-full text-[2rem] leading-[1.3] font-semibold text-[#555555]">
-            {product.subtitle}
-          </p>
+          <p className="title4 w-full text-gray-900">{product.title}</p>
+          <p className="title5 w-full text-gray-600">{product.subtitle}</p>
         </div>
 
         <button
           type="button"
           onClick={() => onClick?.(product)}
           aria-label={`${product.title} 상세 보기`}
-          className="flex h-[4.5rem] w-[4.5rem] items-center justify-center rounded-[1rem] bg-[#333333]"
+          className="flex h-[4.5rem] w-[4.5rem] items-center justify-center rounded-[1rem] bg-gray-900"
         >
-          <Icon name="admin-arrow" size={4.5} />
+          <Icon name="admin-arrow" className="text-gray-50" size={4.5} />
         </button>
       </div>
     </article>

--- a/src/shared/components/product-section/product-section-container.tsx
+++ b/src/shared/components/product-section/product-section-container.tsx
@@ -26,8 +26,12 @@ export default function ProductSectionContainer({
     title,
     actionLabel,
     categories,
+    categoryLabels,
     activeCategory,
     products: filteredProducts,
+    isLoading,
+    isError,
+    isArrowDisabled,
     setActiveCategory,
     handleClickAll,
     handleClickArrow,
@@ -45,8 +49,12 @@ export default function ProductSectionContainer({
       title={title}
       actionLabel={actionLabel}
       categories={categories}
+      categoryLabels={categoryLabels}
       activeCategory={activeCategory}
       products={filteredProducts}
+      isLoading={isLoading}
+      isError={isError}
+      isArrowDisabled={isArrowDisabled}
       onChangeCategory={setActiveCategory}
       onClickAll={handleClickAll}
       onClickArrow={handleClickArrow}

--- a/src/shared/components/product-section/product-section-view.tsx
+++ b/src/shared/components/product-section/product-section-view.tsx
@@ -6,8 +6,12 @@ type ProductSectionViewProps = {
   title: string;
   actionLabel: string;
   categories: ProductCategory[];
+  categoryLabels: Record<ProductCategory, string>;
   activeCategory: ProductCategory;
   products: ProductItem[];
+  isLoading: boolean;
+  isError: boolean;
+  isArrowDisabled: boolean;
   onChangeCategory: (category: ProductCategory) => void;
   onClickAll: () => void;
   onClickArrow: () => void;
@@ -18,8 +22,12 @@ export default function ProductSectionView({
   title,
   actionLabel,
   categories,
+  categoryLabels,
   activeCategory,
   products,
+  isLoading,
+  isError,
+  isArrowDisabled,
   onChangeCategory,
   onClickAll,
   onClickArrow,
@@ -50,7 +58,7 @@ export default function ProductSectionView({
                       : 'border-transparent text-[#B5B5B5] hover:text-[#888888]',
                   )}
                 >
-                  {category}
+                  {categoryLabels[category]}
                 </button>
               );
             })}
@@ -70,22 +78,40 @@ export default function ProductSectionView({
       </div>
 
       <div className="inline-flex items-start gap-[1.4rem]">
-        <div className="flex items-center gap-[3.4rem]">
-          {products.map((product) => (
-            <ProductCard
-              key={product.id}
-              product={product}
-              onClick={onClickProduct}
-            />
-          ))}
+        <div className="flex min-h-[35.8rem] items-center gap-[3.4rem]">
+          {isLoading ? (
+            <div className="text-[1.6rem] text-gray-500">
+              {'\uC0C1\uD488\uC744 \uBD88\uB7EC\uC624\uB294 \uC911\uC785\uB2C8\uB2E4.'}
+            </div>
+          ) : isError ? (
+            <div className="text-[1.6rem] text-red-500">
+              {'\uC0C1\uD488\uC744 \uBD88\uB7EC\uC624\uC9C0 \uBABB\uD588\uC2B5\uB2C8\uB2E4.'}
+            </div>
+          ) : products.length ? (
+            products.map((product) => (
+              <ProductCard
+                key={product.id}
+                product={product}
+                onClick={onClickProduct}
+              />
+            ))
+          ) : (
+            <div className="text-[1.6rem] text-gray-500">
+              {'\uD45C\uC2DC\uD560 \uC0C1\uD488\uC774 \uC5C6\uC2B5\uB2C8\uB2E4.'}
+            </div>
+          )}
         </div>
 
         <button
           type="button"
           onClick={onClickArrow}
-          aria-label="다음 상품 보기"
+          aria-label={'\uB2E4\uC74C \uC0C1\uD488 \uBCF4\uAE30'}
+          disabled={isArrowDisabled || isLoading}
           className={cn(
             'flex h-[35.8rem] w-[4.1rem] items-center justify-center rounded-[0.383rem]',
+            isArrowDisabled || isLoading
+              ? 'cursor-not-allowed opacity-40'
+              : 'cursor-pointer',
           )}
         >
           <svg

--- a/src/shared/hooks/use-access-status-chart.ts
+++ b/src/shared/hooks/use-access-status-chart.ts
@@ -1,3 +1,4 @@
+import { useGetHits, type GetHitsParams, type HitDTO } from '@apis/telegro';
 import { useEffect, useMemo, useState } from 'react';
 
 export type ChartFilter = 'daily' | 'monthly' | 'weekday' | 'company';
@@ -30,178 +31,208 @@ export type DropdownOption<T extends string> = {
 };
 
 export const FILTER_OPTIONS: DropdownOption<ChartFilter>[] = [
-  { value: 'daily', label: '일별' },
-  { value: 'monthly', label: '월별' },
-  { value: 'weekday', label: '요일별' },
-  { value: 'company', label: '업체별' },
+  { value: 'daily', label: '\uC77C\uACC4' },
+  { value: 'monthly', label: '\uC6D4\uACC4' },
+  { value: 'weekday', label: '\uC694\uC77C\uBCC4' },
+  { value: 'company', label: '\uC5C5\uCCB4\uBCC4' },
 ];
 
 const PAGE_SIZE = 9;
-const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 const MONTH_LABELS = [
-  '1월',
-  '2월',
-  '3월',
-  '4월',
-  '5월',
-  '6월',
-  '7월',
-  '8월',
-  '9월',
-  '10월',
-  '11월',
-  '12월',
-] as const;
-export const MONTHS = MONTH_LABELS;
-
-const DAILY_VALUES = [
-  96, 101, 90, 93, 76, 100, 80, 90, 74, 88, 94, 97, 82, 104, 92, 86, 95, 79,
-  109, 111, 98, 103, 85, 100, 106, 93, 87,
-];
-
-const COMPANY_VALUES = [
-  ['A업체', 160],
-  ['B업체', 132],
-  ['C업체', 98],
-  ['D업체', 174],
-  ['E업체', 146],
-  ['F업체', 120],
-  ['G업체', 154],
-  ['H업체', 111],
-  ['I업체', 139],
-  ['J업체', 126],
-  ['K업체', 118],
-  ['L업체', 143],
+  '1\uC6D4',
+  '2\uC6D4',
+  '3\uC6D4',
+  '4\uC6D4',
+  '5\uC6D4',
+  '6\uC6D4',
+  '7\uC6D4',
+  '8\uC6D4',
+  '9\uC6D4',
+  '10\uC6D4',
+  '11\uC6D4',
+  '12\uC6D4',
 ] as const;
 
-const WEEKDAY_DATA: DataPoint[] = [
-  { id: 'w-mon', label: '월', tooltipLabel: '월요일', value: 124 },
-  { id: 'w-tue', label: '화', tooltipLabel: '화요일', value: 118 },
-  { id: 'w-wed', label: '수', tooltipLabel: '수요일', value: 102 },
-  { id: 'w-thu', label: '목', tooltipLabel: '목요일', value: 110 },
-  { id: 'w-fri', label: '금', tooltipLabel: '금요일', value: 145 },
-  { id: 'w-sat', label: '토', tooltipLabel: '토요일', value: 84 },
-  { id: 'w-sun', label: '일', tooltipLabel: '일요일', value: 72 },
-];
-
-const MONTHLY_VALUES_BY_YEAR: Record<number, number[]> = {
-  2025: [84, 92, 101, 95, 104, 112, 118, 115, 109, 121, 96, 89],
-  2026: [88, 103, 116, 99, 91, 107, 121, 114, 108, 124, 111, 97],
-  2027: [93, 108, 119, 104, 98, 112, 127, 120, 114, 129, 115, 101],
+const WEEKDAY_LABEL_MAP: Record<string, { label: string; sort: number }> = {
+  MONDAY: { label: '\uC6D4', sort: 0 },
+  TUESDAY: { label: '\uD654', sort: 1 },
+  WEDNESDAY: { label: '\uC218', sort: 2 },
+  THURSDAY: { label: '\uBAA9', sort: 3 },
+  FRIDAY: { label: '\uAE08', sort: 4 },
+  SATURDAY: { label: '\uD1A0', sort: 5 },
+  SUNDAY: { label: '\uC77C', sort: 6 },
 };
 
-function sumValues(data: DataPoint[]) {
-  return data.reduce((total, item) => total + item.value, 0);
-}
+const HIT_FILTER_MAP: Record<ChartFilter, string> = {
+  daily: 'daily',
+  monthly: 'monthly',
+  weekday: 'weekly',
+  company: 'company',
+};
+
+export const MONTHS = MONTH_LABELS;
 
 function clampPage(page: number, maxPage: number) {
   return Math.min(Math.max(page, 0), maxPage);
 }
 
-function formatDate(date: Date) {
-  return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+function sumValues(data: DataPoint[]) {
+  return data.reduce((total, item) => total + item.value, 0);
 }
 
-function buildDailyData(page: number): DatasetPayload {
-  const allData = DAILY_VALUES.map((value, index) => {
-    const date = new Date(2026, 2, 3 + index);
-    const dayName = DAY_NAMES[date.getDay()];
+function getHitsParams(
+  filter: ChartFilter,
+  selectedYear: number,
+  selectedMonth: number,
+): GetHitsParams {
+  switch (filter) {
+    case 'daily':
+      return {
+        filteredBy: HIT_FILTER_MAP[filter],
+        year: selectedYear,
+        month: selectedMonth,
+      };
+    case 'monthly':
+      return {
+        filteredBy: HIT_FILTER_MAP[filter],
+        year: selectedYear,
+      };
+    case 'weekday':
+      return {
+        filteredBy: HIT_FILTER_MAP[filter],
+        year: selectedYear,
+        month: selectedMonth,
+      };
+    case 'company':
+      return {
+        filteredBy: HIT_FILTER_MAP[filter],
+        year: selectedYear,
+        month: selectedMonth,
+      };
+  }
+}
 
-    return {
-      id: `d-${index}`,
-      label: dayName,
-      subLabel: String(date.getDate()),
-      tooltipLabel: formatDate(date),
-      value,
-    };
-  });
-
-  const maxPage = Math.max(Math.ceil(allData.length / PAGE_SIZE) - 1, 0);
-  const currentPage = clampPage(page, maxPage);
-  const start = currentPage * PAGE_SIZE;
-  const data = allData.slice(start, start + PAGE_SIZE);
+function parseDailyPoint(hit: HitDTO, selectedYear: number, selectedMonth: number) {
+  const rawName = hit.name?.trim() || '';
+  const day = Number(rawName.replace(/\D/g, ''));
+  const safeDay = Number.isFinite(day) && day > 0 ? day : undefined;
 
   return {
-    totalCount: sumValues(data),
-    data,
-    canGoPrev: currentPage > 0,
-    canGoNext: currentPage < maxPage,
-    pageLabel: `${data[0]?.tooltipLabel ?? ''} - ${data[data.length - 1]?.tooltipLabel ?? ''}`,
+    id: `daily-${rawName || safeDay || 'unknown'}`,
+    label: safeDay ? String(safeDay) : rawName || '-',
+    subLabel: MONTH_LABELS[selectedMonth - 1],
+    tooltipLabel: safeDay
+      ? `${selectedYear}.${String(selectedMonth).padStart(2, '0')}.${String(safeDay).padStart(2, '0')}`
+      : rawName || '-',
+    value: hit.hit ?? 0,
+    sort: safeDay ?? Number.MAX_SAFE_INTEGER,
   };
 }
 
-function buildMonthlyData(year: number, page: number): DatasetPayload {
-  const values = MONTHLY_VALUES_BY_YEAR[year] ?? MONTHLY_VALUES_BY_YEAR[2026];
-  const allData = values.map((value, index) => ({
-    id: `m-${year}-${index + 1}`,
-    label: MONTH_LABELS[index],
-    tooltipLabel: `${year}년 ${index + 1}월`,
-    value,
-  }));
-
-  const maxPage = Math.max(Math.ceil(allData.length / PAGE_SIZE) - 1, 0);
-  const currentPage = clampPage(page, maxPage);
-  const start = currentPage * PAGE_SIZE;
-  const data = allData.slice(start, start + PAGE_SIZE);
+function parseMonthlyPoint(hit: HitDTO, selectedYear: number) {
+  const rawName = hit.name?.trim() || '';
+  const month = Number(rawName.replace(/\D/g, ''));
+  const safeMonth = Number.isFinite(month) && month > 0 ? month : undefined;
 
   return {
-    totalCount: sumValues(data),
-    data,
-    canGoPrev: currentPage > 0,
-    canGoNext: currentPage < maxPage,
-    pageLabel: `${year}년 ${data[0]?.label ?? ''} - ${data[data.length - 1]?.label ?? ''}`,
+    id: `monthly-${rawName || safeMonth || 'unknown'}`,
+    label: safeMonth ? MONTH_LABELS[safeMonth - 1] ?? rawName : rawName || '-',
+    tooltipLabel: safeMonth
+      ? `${selectedYear}.${String(safeMonth).padStart(2, '0')}`
+      : rawName || '-',
+    value: hit.hit ?? 0,
+    sort: safeMonth ?? Number.MAX_SAFE_INTEGER,
   };
 }
 
-function buildWeekdayData(): DatasetPayload {
+function parseWeekdayPoint(hit: HitDTO) {
+  const rawName = hit.name?.trim().toUpperCase() || '';
+  const mapped = WEEKDAY_LABEL_MAP[rawName];
+
   return {
-    totalCount: sumValues(WEEKDAY_DATA),
-    data: WEEKDAY_DATA,
-    canGoPrev: false,
-    canGoNext: false,
-    pageLabel: '요일별 평균',
+    id: `weekday-${rawName || 'unknown'}`,
+    label: mapped?.label ?? (hit.name?.trim() || '-'),
+    tooltipLabel: hit.name?.trim() || '-',
+    value: hit.hit ?? 0,
+    sort: mapped?.sort ?? Number.MAX_SAFE_INTEGER,
   };
 }
 
-function buildCompanyData(page: number): DatasetPayload {
-  const allData = COMPANY_VALUES.map(([name, value], index) => ({
-    id: `c-${index + 1}`,
+function parseCompanyPoint(hit: HitDTO, index: number) {
+  const name = hit.name?.trim() || `Company ${index + 1}`;
+
+  return {
+    id: `company-${index}-${name}`,
     label: name,
     tooltipLabel: name,
-    value,
-  }));
+    value: hit.hit ?? 0,
+    sort: index,
+  };
+}
 
+function mapHitsToData(
+  filter: ChartFilter,
+  hits: HitDTO[],
+  selectedYear: number,
+  selectedMonth: number,
+): DataPoint[] {
+  switch (filter) {
+    case 'daily':
+      return hits
+        .map((hit) => parseDailyPoint(hit, selectedYear, selectedMonth))
+        .sort((a, b) => a.sort - b.sort)
+        .map(({ sort, ...rest }) => rest);
+    case 'monthly':
+      return hits
+        .map((hit) => parseMonthlyPoint(hit, selectedYear))
+        .sort((a, b) => a.sort - b.sort)
+        .map(({ sort, ...rest }) => rest);
+    case 'weekday':
+      return hits
+        .map(parseWeekdayPoint)
+        .sort((a, b) => a.sort - b.sort)
+        .map(({ sort, ...rest }) => rest);
+    case 'company':
+      return hits.map(parseCompanyPoint).map(({ sort, ...rest }) => rest);
+  }
+}
+
+function buildDataset(allData: DataPoint[], page: number, totalCount?: number): DatasetPayload {
   const maxPage = Math.max(Math.ceil(allData.length / PAGE_SIZE) - 1, 0);
   const currentPage = clampPage(page, maxPage);
   const start = currentPage * PAGE_SIZE;
   const data = allData.slice(start, start + PAGE_SIZE);
 
   return {
-    totalCount: sumValues(data),
+    totalCount: totalCount ?? sumValues(allData),
     data,
     canGoPrev: currentPage > 0,
     canGoNext: currentPage < maxPage,
-    pageLabel: `${start + 1} - ${start + data.length}위 업체`,
+    pageLabel: `${start + 1}-${start + data.length}`,
   };
 }
 
 export function useAccessStatusChart() {
   const [filter, setFilter] = useState<ChartFilter>('daily');
-  const [selectedYear, setSelectedYear] = useState(2026);
-  const [selectedMonth, setSelectedMonth] = useState(3);
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+  const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth() + 1);
   const [isReady, setIsReady] = useState(false);
   const [isFilterMenuOpen, setIsFilterMenuOpen] = useState(false);
   const [isMonthPickerOpen, setIsMonthPickerOpen] = useState(false);
   const [isYearPickerOpen, setIsYearPickerOpen] = useState(false);
   const [hovered, setHovered] = useState<HoverState>(null);
-  const [pageByFilter, setPageByFilter] = useState<Record<ChartFilter, number>>(
-    {
-      daily: 0,
-      monthly: 0,
-      weekday: 0,
-      company: 0,
+  const [pageByFilter, setPageByFilter] = useState<Record<ChartFilter, number>>({
+    daily: 0,
+    monthly: 0,
+    weekday: 0,
+    company: 0,
+  });
+
+  const hitsQuery = useGetHits(getHitsParams(filter, selectedYear, selectedMonth), {
+    query: {
+      staleTime: 60_000,
     },
-  );
+  });
 
   useEffect(() => {
     const raf = window.requestAnimationFrame(() => setIsReady(true));
@@ -213,50 +244,58 @@ export function useAccessStatusChart() {
     if (filter !== 'daily') {
       setIsMonthPickerOpen(false);
     }
-    if (filter !== 'monthly') {
+    if (filter !== 'monthly' && filter !== 'daily') {
       setIsYearPickerOpen(false);
     }
   }, [filter, selectedYear, selectedMonth, pageByFilter]);
 
   useEffect(() => {
-    setPageByFilter((prev) => ({ ...prev, monthly: 0 }));
-  }, [selectedYear]);
-
-  useEffect(() => {
     setPageByFilter((prev) => ({
       ...prev,
-      monthly: selectedMonth >= 10 ? 1 : 0,
+      [filter]: 0,
     }));
-  }, [selectedMonth]);
+  }, [filter, selectedYear, selectedMonth]);
 
-  const dataset = useMemo(() => {
-    switch (filter) {
-      case 'daily':
-        return buildDailyData(pageByFilter.daily);
-      case 'monthly':
-        return buildMonthlyData(selectedYear, pageByFilter.monthly);
-      case 'weekday':
-        return buildWeekdayData();
-      case 'company':
-        return buildCompanyData(pageByFilter.company);
-    }
-  }, [filter, pageByFilter, selectedYear]);
+  const chartData = useMemo(
+    () =>
+      mapHitsToData(
+        filter,
+        hitsQuery.data?.data?.hits ?? [],
+        selectedYear,
+        selectedMonth,
+      ),
+    [filter, hitsQuery.data?.data?.hits, selectedMonth, selectedYear],
+  );
+
+  const dataset = useMemo(
+    () =>
+      buildDataset(
+        chartData,
+        pageByFilter[filter],
+        hitsQuery.data?.data?.totalHit ??
+          hitsQuery.data?.data?.overAllTotalHit ??
+          hitsQuery.data?.data?.averageHit,
+      ),
+    [
+      chartData,
+      filter,
+      hitsQuery.data?.data?.averageHit,
+      hitsQuery.data?.data?.overAllTotalHit,
+      hitsQuery.data?.data?.totalHit,
+      pageByFilter,
+    ],
+  );
 
   const activeFilterLabel =
-    FILTER_OPTIONS.find((option) => option.value === filter)?.label ?? '일별';
+    FILTER_OPTIONS.find((option) => option.value === filter)?.label ??
+    '\uC77C\uACC4';
 
   function movePage(direction: 'prev' | 'next') {
     setPageByFilter((prev) => {
       const delta = direction === 'prev' ? -1 : 1;
-      const nextPage = Math.max(prev[filter] + delta, 0);
-
-      if (filter === 'monthly') {
-        setSelectedMonth(nextPage === 0 ? 1 : 10);
-      }
-
       return {
         ...prev,
-        [filter]: nextPage,
+        [filter]: Math.max(prev[filter] + delta, 0),
       };
     });
   }
@@ -279,8 +318,10 @@ export function useAccessStatusChart() {
     isYearPickerOpen,
     setIsYearPickerOpen,
     activeFilterLabel,
-    activeMonthLabel: `${selectedMonth}월`,
-    activeYearLabel: `${selectedYear}년`,
+    activeMonthLabel: `${selectedMonth}\uC6D4`,
+    activeYearLabel: `${selectedYear}\uB144`,
+    isLoading: hitsQuery.isLoading,
+    isError: hitsQuery.isError,
     goToPrevPage: () => movePage('prev'),
     goToNextPage: () => movePage('next'),
   };

--- a/src/shared/hooks/use-notice-section.ts
+++ b/src/shared/hooks/use-notice-section.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useGetNotices } from '@apis/telegro';
 
 export type NoticeItem = {
   id: number;
@@ -13,37 +14,64 @@ type UseNoticeSectionParams = {
   onClickAll?: () => void;
 };
 
-const DEFAULT_NOTICES: NoticeItem[] = [
-  {
-    id: 52,
-    title: '공지사항 타이틀이 들어갑니다.',
-    preview:
-      '이 부분은 내용 미리보기가 들어갑니다. 이 부분은 내용 미리보기가 들어갑니다. 이 부분은 내용 미리보기가 들어갑니다. 이 부분은 내용 미리보기가 들어갑니다. 이 부분은 내용 미리보기가 들어갑니다. 이 부분은 내용 미리보기가 들어갑니다. 이 부분은 내용 미리보기가 들어갑니다. 이 부분은 내용 미리보기가 들어갑니다.',
-    views: 99,
-    dateLabel: '22시간 전',
-  },
-  {
-    id: 51,
-    title: '공지사항 타이틀이 들어갑니다.',
-    preview:
-      '이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다. 이건 세 줄까지만 보입니다.',
-    views: 99,
-    dateLabel: '2026.03.27',
-  },
-];
+const FALLBACK_PREVIEW =
+  '\uACF5\uC9C0 \uC0C1\uC138 \uD398\uC774\uC9C0\uC5D0\uC11C \uBCF8\uBB38\uC744 \uD655\uC778\uD560 \uC218 \uC788\uC2B5\uB2C8\uB2E4.';
+
+const formatNoticeDate = (value?: string) => {
+  if (!value) return '-';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}.${month}.${day}`;
+};
 
 export function useNoticeSection({
   notices,
   onClickAll,
 }: UseNoticeSectionParams = {}) {
+  const hasInjectedNotices = Boolean(notices?.length);
+  const noticeQuery = useGetNotices(
+    { page: 0, size: 2 },
+    {
+      query: {
+        staleTime: 60_000,
+      },
+    },
+  );
+
   const resolvedNotices = useMemo(() => {
-    return notices?.length ? notices : DEFAULT_NOTICES;
-  }, [notices]);
+    if (notices?.length) {
+      return notices;
+    }
+
+    return (noticeQuery.data?.data?.notices ?? []).map((notice) => ({
+      id: notice.id ?? 0,
+      title:
+        notice.noticeTitle?.trim() ||
+        '\uC81C\uBAA9 \uC5C6\uB294 \uACF5\uC9C0\uC0AC\uD56D',
+      preview:
+        notice.noticeFileName?.trim() ||
+        notice.noticeAuthor?.trim() ||
+        FALLBACK_PREVIEW,
+      views: notice.viewCount ?? 0,
+      dateLabel: formatNoticeDate(notice.noticeCreateDate),
+    }));
+  }, [noticeQuery.data?.data?.notices, notices]);
 
   return {
-    title: '공지사항',
-    actionLabel: '전체 공지사항 확인하기',
+    title: '\uACF5\uC9C0\uC0AC\uD56D',
+    actionLabel:
+      '\uC804\uCCB4 \uACF5\uC9C0\uC0AC\uD56D \uD655\uC778\uD558\uAE30',
     notices: resolvedNotices,
+    isLoading: hasInjectedNotices ? false : noticeQuery.isLoading,
+    isError: hasInjectedNotices ? false : noticeQuery.isError,
     handleClickAll: () => {
       onClickAll?.();
     },

--- a/src/shared/hooks/use-product-section.ts
+++ b/src/shared/hooks/use-product-section.ts
@@ -1,6 +1,9 @@
-import { useMemo, useState } from 'react';
+import { telegroPrefetch, useGetProducts, type GetProductsCategory } from '@apis/telegro';
+import { formatNumber } from '@utils/format';
+import { useEffect, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
-export type ProductCategory = '헤드셋' | '라인코드' | '녹음기기' | '악세사리';
+export type ProductCategory = GetProductsCategory;
 
 export type ProductItem = {
   id: number;
@@ -19,105 +22,136 @@ type UseProductSectionParams = {
   onClickProduct?: (product: ProductItem) => void;
 };
 
-const DEFAULT_PRODUCTS: ProductItem[] = [
-  {
-    id: 1,
-    category: '헤드셋',
-    title: '커널형 이어셋',
-    subtitle: '명품 이어셋',
-    priceLabel: '10,000원',
-    imageSrc: '/product1.png',
-  },
-  {
-    id: 2,
-    category: '헤드셋',
-    title: '커널형 이어셋',
-    subtitle: '명품 이어셋',
-    priceLabel: '10,000원',
-    imageSrc: '/product1.png',
-  },
-  {
-    id: 3,
-    category: '헤드셋',
-    title: '커널형 이어셋',
-    subtitle: '명품 이어셋',
-    priceLabel: '10,000원',
-    imageSrc: '/product1.png',
-  },
-  {
-    id: 4,
-    category: '라인코드',
-    title: '프리미엄 라인코드',
-    subtitle: '고음질 케이블',
-    priceLabel: '18,000원',
-    imageSrc: '/product1.png',
-  },
-  {
-    id: 5,
-    category: '녹음기기',
-    title: '보이스 레코더',
-    subtitle: '휴대용 녹음기',
-    priceLabel: '39,000원',
-    imageSrc: '/product1.png',
-  },
-  {
-    id: 6,
-    category: '악세사리',
-    title: '이어패드 세트',
-    subtitle: '교체용 악세사리',
-    priceLabel: '12,000원',
-    imageSrc: '/product1.png',
-  },
-  {
-    id: 7,
-    category: '악세사리',
-    title: '이어패드 세트',
-    subtitle: '교체용 악세사리',
-    priceLabel: '12,000원',
-    imageSrc: '/product1.png',
-  },
-  {
-    id: 8,
-    category: '악세사리',
-    title: '이어패드 세트',
-    subtitle: '교체용 악세사리',
-    priceLabel: '12,000원',
-    imageSrc: '/product1.png',
-  },
+const PAGE_SIZE = 4;
+const CATEGORY_OPTIONS: ProductCategory[] = [
+  'HEADSET',
+  'LINE_CORD',
+  'RECORDER',
+  'ACCESSORY',
 ];
 
-const CATEGORY_OPTIONS: ProductCategory[] = [
-  '헤드셋',
-  '라인코드',
-  '녹음기기',
-  '악세사리',
-];
+const CATEGORY_LABELS: Record<ProductCategory, string> = {
+  HEADSET: '\uD5E4\uB4DC\uC14B',
+  PHONE_AMP: '\uD3F0\uC570\uD504',
+  LINE_CORD: '\uB77C\uC778\uCF54\uB4DC',
+  RECORDER: '\uB179\uC74C\uAE30\uAE30',
+  ACCESSORY: '\uC545\uC138\uC11C\uB9AC',
+};
+
+const getProductPageParams = (category: ProductCategory, page: number) => ({
+  category,
+  page,
+  size: PAGE_SIZE,
+});
+
+const toProductItem = (
+  category: ProductCategory,
+  product: {
+    id?: number;
+    productModel?: string;
+    productName?: string;
+    price?: string;
+    coverImage?: string;
+  },
+): ProductItem => ({
+  id: product.id ?? 0,
+  category,
+  title:
+    product.productName?.trim() || '\uC774\uB984 \uC5C6\uB294 \uC0C1\uD488',
+  subtitle:
+    product.productModel?.trim() ||
+    '\uBAA8\uB378 \uC815\uBCF4 \uC5C6\uC74C',
+  priceLabel: `${formatNumber(product.price)}\uC6D0`,
+  imageSrc: product.coverImage?.trim() || '/product1.png',
+});
 
 export function useProductSection({
-  initialCategory = '헤드셋',
-  products = DEFAULT_PRODUCTS,
+  initialCategory = 'HEADSET',
+  products,
   onClickAll,
   onClickArrow,
   onClickProduct,
 }: UseProductSectionParams = {}) {
+  const queryClient = useQueryClient();
+  const hasInjectedProducts = Boolean(products?.length);
   const [activeCategory, setActiveCategory] =
     useState<ProductCategory>(initialCategory);
+  const [pageByCategory, setPageByCategory] = useState<Record<ProductCategory, number>>({
+    HEADSET: 0,
+    PHONE_AMP: 0,
+    LINE_CORD: 0,
+    RECORDER: 0,
+    ACCESSORY: 0,
+  });
 
-  const filteredProducts = useMemo(() => {
-    return products
-      .filter((product) => product.category === activeCategory)
-      .slice(0, 3);
-  }, [activeCategory, products]);
+  const currentPage = pageByCategory[activeCategory];
+  const productQuery = useGetProducts(getProductPageParams(activeCategory, currentPage), {
+    query: {
+      staleTime: 60_000,
+    },
+  });
+
+  useEffect(() => {
+    CATEGORY_OPTIONS.forEach((category) => {
+      void telegroPrefetch.products(queryClient, getProductPageParams(category, 0));
+    });
+  }, [queryClient]);
+
+  useEffect(() => {
+    if (!productQuery.data?.data?.isLast) {
+      void telegroPrefetch.products(
+        queryClient,
+        getProductPageParams(activeCategory, currentPage + 1),
+      );
+    }
+  }, [activeCategory, currentPage, productQuery.data?.data?.isLast, queryClient]);
+
+  const resolvedProducts = useMemo(() => {
+    if (products?.length) {
+      return products.filter((product) => product.category === activeCategory);
+    }
+
+    return (productQuery.data?.data?.products ?? []).map((product) =>
+      toProductItem(activeCategory, product),
+    );
+  }, [activeCategory, productQuery.data?.data?.products, products]);
+
+  const handleChangeCategory = (category: ProductCategory) => {
+    setActiveCategory(category);
+  };
+
+  const handleClickArrow = () => {
+    if (products?.length) {
+      onClickArrow?.();
+      return;
+    }
+
+    if (productQuery.data?.data?.isLast) {
+      return;
+    }
+
+    setPageByCategory((prev) => ({
+      ...prev,
+      [activeCategory]: prev[activeCategory] + 1,
+    }));
+    onClickArrow?.();
+  };
 
   return {
-    title: '상품 목록 확인하기',
-    actionLabel: '전체 상품 확인하기',
+    title: '\uC0C1\uD488 \uBAA9\uB85D \uD655\uC778\uD558\uAE30',
+    actionLabel: '\uC804\uCCB4 \uC0C1\uD488 \uD655\uC778\uD558\uAE30',
     categories: CATEGORY_OPTIONS,
+    categoryLabels: CATEGORY_LABELS,
     activeCategory,
-    products: filteredProducts,
-    setActiveCategory,
+    products: resolvedProducts,
+    isLoading: hasInjectedProducts ? false : productQuery.isLoading,
+    isError: hasInjectedProducts ? false : productQuery.isError,
+    isArrowDisabled: hasInjectedProducts
+      ? resolvedProducts.length <= PAGE_SIZE
+      : Boolean(productQuery.data?.data?.isLast),
+    setActiveCategory: handleChangeCategory,
     handleClickAll: () => onClickAll?.(),
-    handleClickArrow: () => onClickArrow?.(),
+    handleClickArrow,
     handleClickProduct: (product: ProductItem) => onClickProduct?.(product),
   };
 }


### PR DESCRIPTION
  Closes #14                                                                                                                          
                                                                                                                                      
  ## 작업 설명                                                                                                                        
                                                                                                                                      
  관리자 대시보드와 사용자 메인 페이지의 API 연동을 진행했습니다.                                                                     
  관리자 대시보드에서는 공지사항, 상품, 접속 통계(hits)를 실제 API 데이터로 조회하도록 변경했고,                                      
  사용자 메인 페이지에서는 진입 시 방문 기록 API가 호출되도록 연결했습니다.                                                           
                                                                                                                                      
  ## 해결한 TODO                                                                                                                      
                                                                                                                                      
  - [x] 관리자 대시보드 공지사항 API 연동                                                                                             
  - [x] 관리자 대시보드 상품 카테고리별 조회 및 4개 단위 페이징 연동                                                                  
  - [x] 관리자 대시보드 hits 그래프 API 연동                                                                                          
  - [x] 일반 사용자 메인 페이지 hits 기록 API 연동                                                                                    
  - [x] 개발 환경 StrictMode로 인한 홈 hits 중복 전송 방지                                                                            
                                                                                                                                      
  ## 상세 설명                                                                                                                        
                                                                                                                                      
  - 관리자 대시보드 공지사항                                                                                                          
    - `getNotices(page=0, size=2)`로 상위 2개만 조회하도록 변경했습니다.                                                              
    - 로딩, 에러, 빈 상태 UI를 추가했습니다.                                                                                          
    - 공지 카드 클릭 시 관리자 공지 상세 페이지로 이동하도록 연결했습니다.                                                            
                                                                                                                                      
  - 관리자 대시보드 상품                                                                                                              
    - 카테고리별로 `getProducts(category, page, size=4)`를 호출하도록 변경했습니다.                                                   
    - 기본적으로 각 카테고리의 상위 4개를 보여주고, 우측 화살표 클릭 시 다음 4개를 조회합니다.                                        
    - 마지막 페이지에서는 화살표가 비활성화되도록 처리했습니다.                                                                       
    - 상품 카드 클릭 및 전체 보기 버튼을 관리자 상품 페이지 라우트와 연결했습니다.                                                    
                                                                                                                                      
  - 관리자 대시보드 접속 통계                                                                                                         
    - 기존 목데이터 그래프를 `getHits` API 기반으로 교체했습니다.                                                                     
    - 필터별 파라미터는 아래 기준으로 맞췄습니다.                                                                                     
      - `daily` -> `filteredBy=daily&year={year}&month={month}`                                                                       
      - `monthly` -> `filteredBy=monthly&year={year}`                                                                                 
      - `weekday` -> `filteredBy=weekly&year={year}&month={month}`                                                                    
      - `company` -> `filteredBy=company&year={year}&month={month}`                                                                   
    - 응답의 `hits`, `totalHit`, `overAllTotalHit`, `averageHit`를 그래프/합계 표시 값에 반영했습니다.                                
    - 그래프도 9개 단위로 클라이언트 페이징되도록 유지했습니다.                                                                       
    - 로딩, 에러, 빈 상태 UI를 추가했습니다.                                                                                          
                                                                                                                                      
  - 사용자 메인 페이지 방문 기록                                                                                                      
    - 메인 페이지 진입 시 `POST /hits`가 호출되도록 연동했습니다.                                                                     
    - 프로젝트의 기존 API 레이어 `useRecordHits`를 사용했습니다.                                                                      
    - 개발 모드 `StrictMode`로 인해 effect가 2회 실행되며 hit가 중복 기록되는 문제를 막기 위해 `sessionStorage` 기반 중복 방지 가드를 
  추가했습니다.                                                                                                                       
                                                                                                                                      
  ## 변경 내용                                                                                                                        
                                                                                                                                      
  - 관리자 대시보드 공지사항/상품/접속 통계 섹션을 목데이터 기반에서 API 기반으로 전환                                                
  - 상품 카테고리별 4개 단위 다음 페이지 조회 기능 추가                                                                               
  - 접속 통계 필터별 API 파라미터 연동                                                                                                
  - 사용자 메인 페이지 방문 기록 API 호출 추가                                                                                        
  - 개발 환경 중복 hit 방지 처리 추가                                                                                                 
                                                                                                                                      
  ## Screenshots or Video                                                                                                             
                                                                                                                                      
  - UI 구조 변경보다는 데이터 연동 중심 작업이라 별도 스크린샷은 생략했습니다.                                                        
  - 필요 시 관리자 대시보드 공지/상품/접속통계와 사용자 메인 진입 hit 기록 동작 영상 추가 가능합니다.                                 
                                                                                                                                      
  ## ETC
                                                                                                                                      
  - 로컬 코드 기준으로 데이터 연동 로직을 반영했습니다.                                                                                                      
  - 추후 API가 수정되는 대로 공지사항의 경우 내용이 세 줄까지 보이도록 수정하는 작업이 필요합니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added page hit tracking to record user sessions.
  * Added loading and error state indicators across dashboard components (access status, notices, products).

* **Improvements**
  * Enhanced admin navigation with direct routing.
  * Improved product card styling and category label management.
  * Replaced static fallback data with dynamic API-driven content for products, notices, and access status data.
  * Refined chart filter behavior and date label formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->