### PR TITLE
[Feat/#25] 공지사항 등록/수정/삭제/고정 API 연동 (Admin)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "dependencies": {
     "@tanstack/react-query": "^5.85.0",
     "@tanstack/react-query-devtools": "^5.87.3",
+    "@toast-ui/editor": "^3.2.2",
+    "@toast-ui/editor-plugin-color-syntax": "^3.1.0",
+    "@toast-ui/react-editor": "^3.2.3",
     "clsx": "^2.1.1",
     "jotai": "^2.14.0",
     "jotai-utils": "^0.0.0",
@@ -24,6 +27,7 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.8.0",
     "tailwind-merge": "^3.3.1",
+    "tui-color-picker": "^2.2.8",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,15 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.87.3
         version: 5.87.3(@tanstack/react-query@5.85.0(react@19.1.1))(react@19.1.1)
+      '@toast-ui/editor':
+        specifier: ^3.2.2
+        version: 3.2.2
+      '@toast-ui/editor-plugin-color-syntax':
+        specifier: ^3.1.0
+        version: 3.1.0
+      '@toast-ui/react-editor':
+        specifier: ^3.2.3
+        version: 3.2.3(react@19.1.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -41,6 +50,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
+      tui-color-picker:
+        specifier: ^2.2.8
+        version: 2.2.8
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.2)(vite@7.1.2(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -1058,6 +1070,17 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@toast-ui/editor-plugin-color-syntax@3.1.0':
+    resolution: {integrity: sha512-UVKfMBPV+3snSaJn9RUKGbxJbgi92D2t68ow8wAjGezvMp1ht4UVETrvomdTGr+RYhXSeH3JvSwN9nmQqw0qzA==}
+
+  '@toast-ui/editor@3.2.2':
+    resolution: {integrity: sha512-ASX7LFjN2ZYQJrwmkUajPs7DRr9FsM1+RQ82CfTO0Y5ZXorBk1VZS4C2Dpxinx9kl55V4F8/A2h2QF4QMDtRbA==}
+
+  '@toast-ui/react-editor@3.2.3':
+    resolution: {integrity: sha512-86QdgiOkBeSwRBEUWRKsTpnm6yu5j9HNJ3EfQN8EGcd7kI8k8AhExXyUJ3NNgNTzN7FfSKMw+1VaCDDC+aZ3dw==}
+    peerDependencies:
+      react: ^17.0.1
+
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -1534,6 +1557,9 @@ packages:
   domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
+
+  dompurify@2.5.9:
+    resolution: {integrity: sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==}
 
   domutils@1.7.0:
     resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
@@ -2633,6 +2659,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   orval@7.11.2:
     resolution: {integrity: sha512-Cjc/dgnQwAOkvymzvPpFqFc2nQwZ29E+ZFWUI8yKejleHaoFKIdwvkM/b1njtLEjePDcF0hyqXXCTz2wWaXLig==}
     hasBin: true
@@ -2811,6 +2840,30 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-model@1.25.4:
+    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-transform@1.11.0:
+    resolution: {integrity: sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==}
+
+  prosemirror-view@1.41.7:
+    resolution: {integrity: sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -2937,6 +2990,9 @@ packages:
     resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3247,6 +3303,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tui-color-picker@2.2.8:
+    resolution: {integrity: sha512-q5sE9NQ5NR9lYpilYjcI7Sdv0KCogo+W8fZY+AYTj/HYg+9fscYy3UuJ6UQiV1bF+ARCLwFRWC8UcOt9kuUctQ==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3402,6 +3461,9 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -4461,6 +4523,26 @@ snapshots:
       '@tanstack/query-core': 5.83.1
       react: 19.1.1
 
+  '@toast-ui/editor-plugin-color-syntax@3.1.0':
+    dependencies:
+      tui-color-picker: 2.2.8
+
+  '@toast-ui/editor@3.2.2':
+    dependencies:
+      dompurify: 2.5.9
+      prosemirror-commands: 1.7.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.7
+
+  '@toast-ui/react-editor@3.2.3(react@19.1.1)':
+    dependencies:
+      '@toast-ui/editor': 3.2.2
+      react: 19.1.1
+
   '@trysound/sax@0.2.0': {}
 
   '@types/babel__core@7.20.5':
@@ -4950,6 +5032,8 @@ snapshots:
   domhandler@4.3.1:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@2.5.9: {}
 
   domutils@1.7.0:
     dependencies:
@@ -6140,6 +6224,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  orderedmap@2.1.1: {}
+
   orval@7.11.2(openapi-types@12.1.3):
     dependencies:
       '@apidevtools/swagger-parser': 10.1.1(openapi-types@12.1.3)
@@ -6278,6 +6364,49 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-model@1.25.4:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.7
+
+  prosemirror-transform@1.11.0:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-view@1.41.7:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
   proxy-from-env@1.1.0: {}
 
   punycode.js@2.3.1: {}
@@ -6405,6 +6534,8 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.46.2
       '@rollup/rollup-win32-x64-msvc': 4.46.2
       fsevents: 2.3.3
+
+  rope-sequence@1.3.4: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -6775,6 +6906,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tui-color-picker@2.2.8: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -6929,6 +7062,8 @@ snapshots:
       lightningcss: 1.30.1
       tsx: 4.21.0
       yaml: 2.8.1
+
+  w3c-keyname@2.2.8: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/pages/admin/notices/create.tsx
+++ b/src/pages/admin/notices/create.tsx
@@ -24,6 +24,11 @@ import 'tui-color-picker/dist/tui-color-picker.css';
 import '@toast-ui/editor-plugin-color-syntax/dist/toastui-editor-plugin-color-syntax.css';
 
 const isHtmlEmpty = (value: string) => {
+  const hasMediaContent = /<(img|video|iframe|audio|object|embed)\b/i.test(value);
+  if (hasMediaContent) {
+    return false;
+  }
+
   const normalized = value
     .replace(/<br\s*\/?>/gi, '')
     .replace(/&nbsp;/gi, ' ')
@@ -61,6 +66,7 @@ const AdminNoticeCreate = () => {
   const isHydratedRef = useRef(false);
 
   const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
   const [noticeFiles, setNoticeFiles] = useState<NoticeFile[]>([]);
   const [error, setError] = useState('');
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
@@ -97,7 +103,9 @@ const AdminNoticeCreate = () => {
         fileUrl: file.fileUrl?.trim() || '',
       })),
     );
-    editorInstance.setHTML(detail.noticeContent?.trim() || '');
+    const nextContent = detail.noticeContent?.trim() || '';
+    editorInstance.setHTML(nextContent);
+    setContent(nextContent);
     isHydratedRef.current = true;
   }, [isEditMode, noticeDetailQuery.data?.data]);
 
@@ -177,7 +185,7 @@ const AdminNoticeCreate = () => {
     event.preventDefault();
 
     const editorInstance = editorRef.current?.getInstance();
-    const htmlContent = editorInstance?.getHTML() ?? '';
+    const htmlContent = editorInstance?.getHTML() ?? content;
 
     if (!title.trim()) {
       setError('제목을 입력해 주세요.');
@@ -340,6 +348,10 @@ const AdminNoticeCreate = () => {
                 initialEditType="wysiwyg"
                 useCommandShortcut
                 hooks={{ addImageBlobHook }}
+                onChange={() => {
+                  const nextContent = editorRef.current?.getInstance().getHTML() ?? '';
+                  setContent(nextContent);
+                }}
                 toolbarItems={[
                   ['heading', 'bold', 'italic', 'strike'],
                   ['hr', 'quote'],

--- a/src/pages/admin/notices/create.tsx
+++ b/src/pages/admin/notices/create.tsx
@@ -1,6 +1,8 @@
 import {
   createNotice,
   getPresignedUrl,
+  updateNotice,
+  useGetNoticeDetail,
   type NoticeFile,
 } from '@apis/telegro';
 import AdminProfileCard from '@components/admin/profile-card/profile-card';
@@ -8,9 +10,15 @@ import queryClient from '@libs/query-client';
 import { Editor } from '@toast-ui/react-editor';
 import axios from 'axios';
 import color from '@toast-ui/editor-plugin-color-syntax';
-import { useRef, useState, type ChangeEvent, type MouseEvent } from 'react';
-import toast from 'react-hot-toast';
-import { useNavigate } from 'react-router-dom';
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type MouseEvent,
+} from 'react';
+import { toastError, toastSuccess } from '@components/common/toast/toast';
+import { useNavigate, useParams } from 'react-router-dom';
 import '@toast-ui/editor/dist/toastui-editor.css';
 import 'tui-color-picker/dist/tui-color-picker.css';
 import '@toast-ui/editor-plugin-color-syntax/dist/toastui-editor-plugin-color-syntax.css';
@@ -34,16 +42,64 @@ const getUploadFileName = (file: Blob | File) => {
   return `notice-image-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${extension}`;
 };
 
+const invalidateNoticeQueries = () =>
+  queryClient.invalidateQueries({
+    predicate: (query) =>
+      Array.isArray(query.queryKey) &&
+      typeof query.queryKey[0] === 'string' &&
+      query.queryKey[0].startsWith('/notices'),
+  });
+
 const AdminNoticeCreate = () => {
   const navigate = useNavigate();
+  const { noticeId } = useParams();
+  const resolvedNoticeId = Number(noticeId);
+  const isEditMode = Number.isFinite(resolvedNoticeId) && resolvedNoticeId > 0;
+
   const editorRef = useRef<Editor>(null);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
+  const isHydratedRef = useRef(false);
 
   const [title, setTitle] = useState('');
   const [noticeFiles, setNoticeFiles] = useState<NoticeFile[]>([]);
   const [error, setError] = useState('');
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const noticeDetailQuery = useGetNoticeDetail(resolvedNoticeId, {
+    query: {
+      enabled: isEditMode,
+      staleTime: 60_000,
+    },
+  });
+
+  useEffect(() => {
+    isHydratedRef.current = false;
+  }, [resolvedNoticeId]);
+
+  useEffect(() => {
+    if (!isEditMode || isHydratedRef.current) {
+      return;
+    }
+
+    const detail = noticeDetailQuery.data?.data;
+    const editorInstance = editorRef.current?.getInstance();
+
+    if (!detail || !editorInstance) {
+      return;
+    }
+
+    setTitle(detail.noticeTitle?.trim() || '');
+    setNoticeFiles(
+      (detail.noticeFiles ?? []).map((file) => ({
+        id: file.id,
+        fileName: file.fileName?.trim() || '',
+        fileUrl: file.fileUrl?.trim() || '',
+      })),
+    );
+    editorInstance.setHTML(detail.noticeContent?.trim() || '');
+    isHydratedRef.current = true;
+  }, [isEditMode, noticeDetailQuery.data?.data]);
 
   const uploadToPresignedUrl = async (
     file: Blob | File,
@@ -85,10 +141,10 @@ const AdminNoticeCreate = () => {
       );
 
       setNoticeFiles((prev) => [...prev, ...uploadedFiles]);
-      toast.success('첨부파일 업로드를 완료했습니다.');
+      toastSuccess('첨부파일 업로드를 완료했습니다.');
     } catch {
       setError('파일 업로드 중 오류가 발생했습니다.');
-      toast.error('파일 업로드에 실패했습니다.');
+      toastError('파일 업로드에 실패했습니다.');
     } finally {
       setIsUploadingFiles(false);
       event.target.value = '';
@@ -110,10 +166,10 @@ const AdminNoticeCreate = () => {
     try {
       const uploadedImage = await uploadToPresignedUrl(blob);
       callback(uploadedImage.fileUrl ?? '', 'image');
-      toast.success('이미지 업로드를 완료했습니다.');
+      toastSuccess('이미지 업로드를 완료했습니다.');
     } catch {
       setError('이미지 업로드 중 오류가 발생했습니다.');
-      toast.error('이미지 업로드에 실패했습니다.');
+      toastError('이미지 업로드에 실패했습니다.');
     }
   };
 
@@ -137,18 +193,30 @@ const AdminNoticeCreate = () => {
     setIsSubmitting(true);
 
     try {
-      await createNotice({
-        title: title.trim(),
-        context: htmlContent,
-        noticeFiles,
-      });
+      if (isEditMode) {
+        await updateNotice(resolvedNoticeId, {
+          title: title.trim(),
+          context: htmlContent,
+          noticeFiles,
+        });
+      } else {
+        await createNotice({
+          title: title.trim(),
+          context: htmlContent,
+          noticeFiles,
+        });
+      }
 
-      await queryClient.invalidateQueries({
-        queryKey: ['/notices'],
-      });
+      await invalidateNoticeQueries();
 
-      toast.success('공지사항이 등록되었습니다.');
-      navigate('/admin/notices');
+      toastSuccess(
+        isEditMode ? '공지사항을 수정했습니다.' : '공지사항이 등록되었습니다.',
+      );
+      navigate(
+        isEditMode
+          ? `/admin/notices/${resolvedNoticeId}`
+          : '/admin/notices',
+      );
     } catch (submitError) {
       if (
         axios.isAxiosError(submitError) &&
@@ -156,9 +224,17 @@ const AdminNoticeCreate = () => {
       ) {
         setError('관리자 계정으로 로그인해 주세요.');
       } else {
-        setError('공지사항 등록 중 오류가 발생했습니다.');
+        setError(
+          isEditMode
+            ? '공지사항 수정 중 오류가 발생했습니다.'
+            : '공지사항 등록 중 오류가 발생했습니다.',
+        );
       }
-      toast.error('공지사항 등록에 실패했습니다.');
+      toastError(
+        isEditMode
+          ? '공지사항 수정에 실패했습니다.'
+          : '공지사항 등록에 실패했습니다.',
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -174,10 +250,10 @@ const AdminNoticeCreate = () => {
             Admin Notice
           </p>
           <h1 className="mt-[0.8rem] text-[3rem] font-semibold tracking-[-0.04em] text-gray-900">
-            공지사항 등록
+            {isEditMode ? '공지사항 수정' : '공지사항 등록'}
           </h1>
           <p className="mt-[0.8rem] text-[1.5rem] leading-[1.7] text-gray-500">
-            Toast UI 에디터로 본문을 작성하고 첨부파일까지 함께 등록합니다.
+            Toast UI 에디터로 본문을 작성하고 첨부파일까지 함께 관리합니다.
           </p>
         </div>
 
@@ -191,7 +267,8 @@ const AdminNoticeCreate = () => {
               value={title}
               onChange={(event) => setTitle(event.target.value)}
               placeholder="제목을 입력해 주세요."
-              className="h-[5.6rem] rounded-[1.6rem] border border-[#E3E3E3] px-[1.6rem] text-[1.5rem] text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-[#FF9B2F] focus:ring-4 focus:ring-[#FFE4C4]"
+              disabled={isEditMode && noticeDetailQuery.isLoading}
+              className="h-[5.6rem] rounded-[1.6rem] border border-[#E3E3E3] px-[1.6rem] text-[1.5rem] text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-[#FF9B2F] focus:ring-4 focus:ring-[#FFE4C4] disabled:cursor-not-allowed disabled:bg-[#F7F7F7]"
             />
           </label>
 
@@ -203,7 +280,11 @@ const AdminNoticeCreate = () => {
               <button
                 type="button"
                 onClick={() => attachmentInputRef.current?.click()}
-                disabled={isUploadingFiles || isSubmitting}
+                disabled={
+                  isUploadingFiles ||
+                  isSubmitting ||
+                  (isEditMode && noticeDetailQuery.isLoading)
+                }
                 className="inline-flex h-[4.4rem] items-center justify-center rounded-[1.4rem] border border-[#FFD8B0] bg-[#FFF5EA] px-[1.6rem] text-[1.4rem] font-semibold text-[#D86B00] transition hover:bg-[#FFEBD4] disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {isUploadingFiles ? '업로드 중...' : '파일 추가'}
@@ -282,7 +363,11 @@ const AdminNoticeCreate = () => {
           <div className="flex flex-col-reverse gap-[1rem] pt-[0.8rem] sm:flex-row sm:justify-end">
             <button
               type="button"
-              onClick={() => navigate('/admin/notices')}
+              onClick={() =>
+                navigate(
+                  isEditMode ? `/admin/notices/${resolvedNoticeId}` : '/admin/notices',
+                )
+              }
               disabled={isSubmitting}
               className="inline-flex h-[5.2rem] items-center justify-center rounded-[1.6rem] border border-[#E5E7EB] bg-white px-[2rem] text-[1.5rem] font-semibold text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
             >
@@ -291,10 +376,20 @@ const AdminNoticeCreate = () => {
             <button
               type="button"
               onClick={handleSubmit}
-              disabled={isSubmitting || isUploadingFiles}
+              disabled={
+                isSubmitting ||
+                isUploadingFiles ||
+                (isEditMode && noticeDetailQuery.isLoading)
+              }
               className="inline-flex h-[5.2rem] items-center justify-center rounded-[1.6rem] border border-[#FFE2C0] bg-[linear-gradient(135deg,#FF9B2F_0%,#FFB652_100%)] px-[2rem] text-[1.5rem] font-semibold text-white shadow-[0_16px_34px_rgba(255,155,47,0.24)] transition hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0"
             >
-              {isSubmitting ? '등록 중...' : '등록'}
+              {isSubmitting
+                ? isEditMode
+                  ? '수정 중...'
+                  : '등록 중...'
+                : isEditMode
+                  ? '수정'
+                  : '등록'}
             </button>
           </div>
         </div>

--- a/src/pages/admin/notices/create.tsx
+++ b/src/pages/admin/notices/create.tsx
@@ -1,9 +1,305 @@
+import {
+  createNotice,
+  getPresignedUrl,
+  type NoticeFile,
+} from '@apis/telegro';
+import AdminProfileCard from '@components/admin/profile-card/profile-card';
+import queryClient from '@libs/query-client';
+import { Editor } from '@toast-ui/react-editor';
+import axios from 'axios';
+import color from '@toast-ui/editor-plugin-color-syntax';
+import { useRef, useState, type ChangeEvent, type MouseEvent } from 'react';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+import '@toast-ui/editor/dist/toastui-editor.css';
+import 'tui-color-picker/dist/tui-color-picker.css';
+import '@toast-ui/editor-plugin-color-syntax/dist/toastui-editor-plugin-color-syntax.css';
+
+const isHtmlEmpty = (value: string) => {
+  const normalized = value
+    .replace(/<br\s*\/?>/gi, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/<[^>]*>/g, '')
+    .trim();
+
+  return normalized.length === 0;
+};
+
+const getUploadFileName = (file: Blob | File) => {
+  if ('name' in file && file.name) {
+    return file.name;
+  }
+
+  const extension = file.type.split('/')[1] || 'png';
+  return `notice-image-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${extension}`;
+};
+
 const AdminNoticeCreate = () => {
+  const navigate = useNavigate();
+  const editorRef = useRef<Editor>(null);
+  const attachmentInputRef = useRef<HTMLInputElement>(null);
+
+  const [title, setTitle] = useState('');
+  const [noticeFiles, setNoticeFiles] = useState<NoticeFile[]>([]);
+  const [error, setError] = useState('');
+  const [isUploadingFiles, setIsUploadingFiles] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const uploadToPresignedUrl = async (
+    file: Blob | File,
+    fileName = getUploadFileName(file),
+  ): Promise<NoticeFile> => {
+    const response = await getPresignedUrl({
+      prefix: 'notice',
+      fileName,
+    });
+
+    const presignedUrl = response.data?.url;
+
+    if (!presignedUrl) {
+      throw new Error('Presigned URL not found');
+    }
+
+    await axios.put(presignedUrl, file, {
+      headers: {
+        'Content-Type': file.type || 'application/octet-stream',
+      },
+    });
+
+    return {
+      fileName,
+      fileUrl: presignedUrl.split('?')[0],
+    };
+  };
+
+  const handleAddFile = async (event: ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(event.target.files ?? []);
+    if (!selectedFiles.length) return;
+
+    setError('');
+    setIsUploadingFiles(true);
+
+    try {
+      const uploadedFiles = await Promise.all(
+        selectedFiles.map((file) => uploadToPresignedUrl(file, file.name)),
+      );
+
+      setNoticeFiles((prev) => [...prev, ...uploadedFiles]);
+      toast.success('첨부파일 업로드를 완료했습니다.');
+    } catch {
+      setError('파일 업로드 중 오류가 발생했습니다.');
+      toast.error('파일 업로드에 실패했습니다.');
+    } finally {
+      setIsUploadingFiles(false);
+      event.target.value = '';
+    }
+  };
+
+  const handleDeleteFile = (indexToDelete: number) => {
+    setNoticeFiles((prev) =>
+      prev.filter((_, index) => index !== indexToDelete),
+    );
+  };
+
+  const addImageBlobHook = async (
+    blob: Blob | File,
+    callback: (url: string, text?: string) => void,
+  ) => {
+    setError('');
+
+    try {
+      const uploadedImage = await uploadToPresignedUrl(blob);
+      callback(uploadedImage.fileUrl ?? '', 'image');
+      toast.success('이미지 업로드를 완료했습니다.');
+    } catch {
+      setError('이미지 업로드 중 오류가 발생했습니다.');
+      toast.error('이미지 업로드에 실패했습니다.');
+    }
+  };
+
+  const handleSubmit = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+
+    const editorInstance = editorRef.current?.getInstance();
+    const htmlContent = editorInstance?.getHTML() ?? '';
+
+    if (!title.trim()) {
+      setError('제목을 입력해 주세요.');
+      return;
+    }
+
+    if (isHtmlEmpty(htmlContent)) {
+      setError('내용을 입력해 주세요.');
+      return;
+    }
+
+    setError('');
+    setIsSubmitting(true);
+
+    try {
+      await createNotice({
+        title: title.trim(),
+        context: htmlContent,
+        noticeFiles,
+      });
+
+      await queryClient.invalidateQueries({
+        queryKey: ['/notices'],
+      });
+
+      toast.success('공지사항이 등록되었습니다.');
+      navigate('/admin/notices');
+    } catch (submitError) {
+      if (
+        axios.isAxiosError(submitError) &&
+        submitError.response?.status === 403
+      ) {
+        setError('관리자 계정으로 로그인해 주세요.');
+      } else {
+        setError('공지사항 등록 중 오류가 발생했습니다.');
+      }
+      toast.error('공지사항 등록에 실패했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
-    <section>
-      <h1>Create Product (Admin)</h1>
-      {/* form later */}
-    </section>
+    <div className="flex flex-col gap-[4rem] bg-[#FAFAFA] px-[2rem] py-[2rem] md:px-[5rem] md:py-[3rem] lg:px-[10rem] lg:py-[5rem]">
+      <AdminProfileCard onMove={() => navigate('/')} />
+
+      <section className="overflow-hidden rounded-[3rem] border border-[#EAEAEA] bg-white shadow-[0_22px_60px_rgba(15,23,42,0.06)]">
+        <div className="border-b border-[#F1F1F1] bg-[linear-gradient(135deg,#FFF7ED_0%,#FFFFFF_58%)] px-[2.4rem] py-[2.4rem] md:px-[3.2rem]">
+          <p className="text-[1.3rem] font-semibold uppercase tracking-[0.24em] text-[#FF8A1F]">
+            Admin Notice
+          </p>
+          <h1 className="mt-[0.8rem] text-[3rem] font-semibold tracking-[-0.04em] text-gray-900">
+            공지사항 등록
+          </h1>
+          <p className="mt-[0.8rem] text-[1.5rem] leading-[1.7] text-gray-500">
+            Toast UI 에디터로 본문을 작성하고 첨부파일까지 함께 등록합니다.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-[2.4rem] px-[2rem] py-[2.4rem] md:px-[3.2rem] md:py-[3.2rem]">
+          <label className="flex flex-col gap-[0.8rem]">
+            <span className="text-[1.5rem] font-semibold tracking-[-0.03em] text-gray-900">
+              제목 *
+            </span>
+            <input
+              type="text"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="제목을 입력해 주세요."
+              className="h-[5.6rem] rounded-[1.6rem] border border-[#E3E3E3] px-[1.6rem] text-[1.5rem] text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-[#FF9B2F] focus:ring-4 focus:ring-[#FFE4C4]"
+            />
+          </label>
+
+          <div className="flex flex-col gap-[1.2rem]">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-[1.5rem] font-semibold tracking-[-0.03em] text-gray-900">
+                첨부파일
+              </span>
+              <button
+                type="button"
+                onClick={() => attachmentInputRef.current?.click()}
+                disabled={isUploadingFiles || isSubmitting}
+                className="inline-flex h-[4.4rem] items-center justify-center rounded-[1.4rem] border border-[#FFD8B0] bg-[#FFF5EA] px-[1.6rem] text-[1.4rem] font-semibold text-[#D86B00] transition hover:bg-[#FFEBD4] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isUploadingFiles ? '업로드 중...' : '파일 추가'}
+              </button>
+            </div>
+
+            <input
+              ref={attachmentInputRef}
+              type="file"
+              multiple
+              onChange={handleAddFile}
+              className="hidden"
+            />
+
+            {noticeFiles.length ? (
+              <ul className="flex flex-col gap-[0.8rem] rounded-[2rem] border border-[#F0F0F0] bg-[#FCFCFC] p-[1.4rem]">
+                {noticeFiles.map((file, index) => (
+                  <li
+                    key={`${file.fileUrl ?? file.fileName ?? index}-${index}`}
+                    className="flex items-center justify-between gap-4 rounded-[1.4rem] border border-[#F2F2F2] bg-white px-[1.4rem] py-[1.2rem]"
+                  >
+                    <span className="min-w-0 truncate text-[1.4rem] text-gray-700">
+                      {file.fileName || '첨부파일'}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteFile(index)}
+                      disabled={isSubmitting}
+                      className="text-[1.3rem] font-semibold text-red-500 transition hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      삭제
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="rounded-[2rem] border border-dashed border-[#E2E2E2] bg-[#FCFCFC] px-[1.6rem] py-[1.8rem] text-[1.4rem] text-gray-500">
+                업로드한 첨부파일이 없습니다.
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-[1.2rem]">
+            <span className="text-[1.5rem] font-semibold tracking-[-0.03em] text-gray-900">
+              내용 *
+            </span>
+            <div className="overflow-hidden rounded-[2.4rem] border border-[#E3E3E3] bg-white">
+              <Editor
+                ref={editorRef}
+                initialValue=" "
+                previewStyle="vertical"
+                height="500px"
+                initialEditType="wysiwyg"
+                useCommandShortcut
+                hooks={{ addImageBlobHook }}
+                toolbarItems={[
+                  ['heading', 'bold', 'italic', 'strike'],
+                  ['hr', 'quote'],
+                  ['ul', 'ol', 'task', 'indent', 'outdent'],
+                  ['table', 'link', 'image'],
+                ]}
+                plugins={[color]}
+              />
+            </div>
+            <p className="text-[1.3rem] leading-[1.7] text-gray-500">
+              에디터 이미지 버튼을 사용하면 presigned URL 업로드 후 본문에 즉시 삽입됩니다.
+            </p>
+          </div>
+
+          {error ? (
+            <div className="rounded-[1.8rem] border border-[#FFD5D5] bg-[#FFF5F5] px-[1.6rem] py-[1.3rem] text-[1.4rem] text-red-600">
+              {error}
+            </div>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-[1rem] pt-[0.8rem] sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={() => navigate('/admin/notices')}
+              disabled={isSubmitting}
+              className="inline-flex h-[5.2rem] items-center justify-center rounded-[1.6rem] border border-[#E5E7EB] bg-white px-[2rem] text-[1.5rem] font-semibold text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={isSubmitting || isUploadingFiles}
+              className="inline-flex h-[5.2rem] items-center justify-center rounded-[1.6rem] border border-[#FFE2C0] bg-[linear-gradient(135deg,#FF9B2F_0%,#FFB652_100%)] px-[2rem] text-[1.5rem] font-semibold text-white shadow-[0_16px_34px_rgba(255,155,47,0.24)] transition hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0"
+            >
+              {isSubmitting ? '등록 중...' : '등록'}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
   );
 };
 

--- a/src/pages/admin/notices/notice-detail.tsx
+++ b/src/pages/admin/notices/notice-detail.tsx
@@ -7,6 +7,7 @@ const AdminNoticeDetailPage = () => {
 
   return (
     <NoticeDetailContainer
+      isAdmin
       noticeId={Number(noticeId) || undefined}
       onGoList={() => navigate('/admin/notices')}
       onOpenNotice={(id) => navigate(`/admin/notices/${id}`)}

--- a/src/pages/admin/notices/notices.tsx
+++ b/src/pages/admin/notices/notices.tsx
@@ -6,6 +6,7 @@ import NoticeCard from '@components/notice/notice-card';
 import { useNoticeSection } from '@hooks/use-notice-section';
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { FiPlus } from 'react-icons/fi';
 
 const AdminNotices = () => {
   const navigate = useNavigate();
@@ -35,15 +36,19 @@ const AdminNotices = () => {
       <AdminProfileCard onMove={() => navigate('/')} />
 
       <div className="flex flex-col gap-[3.5rem]">
-        <div className="flex flex-wrap items-end justify-between gap-4">
+        <div className="flex items-center gap-[2rem]">
           <h1 className="title3 text-gray-900">공지사항</h1>
-          <button
-            type="button"
-            onClick={() => navigate('/admin/notices/create')}
-            className="inline-flex h-[5.2rem] items-center justify-center rounded-[1.5rem] border border-[#FFE2C0] bg-[linear-gradient(135deg,#FF9B2F_0%,#FFB652_100%)] px-[2rem] text-[1.5rem] font-semibold tracking-[-0.03em] text-white shadow-[0_16px_34px_rgba(255,155,47,0.24)] transition hover:-translate-y-0.5"
-          >
-            공지 등록
-          </button>
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={() => navigate('/admin/notices/create')}
+              aria-label="상공지 등록"
+              title="공지 등록"
+              className="flex-row-center h-[4rem] w-[4rem] cursor-pointer rounded-full bg-[#f5f5f5] transition-colors hover:bg-[#E3E3E3]"
+            >
+              <FiPlus className="text-[2rem] text-gray-600" />
+            </button>
+          </div>
         </div>
 
         <SearchBar

--- a/src/shared/components/admin/notice-detail/admin-notice-detail-view.tsx
+++ b/src/shared/components/admin/notice-detail/admin-notice-detail-view.tsx
@@ -42,10 +42,6 @@ const AdminNoticeDetailView = ({
           <NoticeHeroGraphic />
 
           <article className="flex flex-col gap-8 text-[#202124]">
-            <p className="text-[1.28rem] leading-[1.9] tracking-[-0.02em] text-[#202124] md:text-[1.45rem]">
-              안녕하세요. 텔레그로 운영팀입니다.
-            </p>
-
             {notice.summary ? (
               <p className="text-[1.2rem] leading-[1.95] font-medium tracking-[-0.02em] text-[#5B74F7] md:text-[1.35rem]">
                 {notice.summary}

--- a/src/shared/components/admin/notice-detail/admin-notice-detail-view.tsx
+++ b/src/shared/components/admin/notice-detail/admin-notice-detail-view.tsx
@@ -2,30 +2,103 @@ import NoticeContentCard from '@components/admin/notice-detail/notice-content-ca
 import NoticeHeroGraphic from '@components/admin/notice-detail/notice-hero-graphic';
 import NoticeNavigationRow from '@components/admin/notice-detail/notice-navigation-row';
 import CalendarIcon from '@components/common/calendar-icon';
+import ConfirmModal from '@components/common/confirm-modal';
 import Icon from '@components/common/icon';
 import LoadingPanel from '@components/common/loading-panel';
 import { useAdminNoticeDetail } from '@hooks/use-admin-notice-detail';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-type AdminNoticeDetailViewProps = ReturnType<typeof useAdminNoticeDetail>;
+type AdminNoticeDetailViewProps = ReturnType<typeof useAdminNoticeDetail> & {
+  isAdmin?: boolean;
+};
 
 const AdminNoticeDetailView = ({
+  isAdmin = false,
   notice,
   prevNotice,
   nextNotice,
   isLoading,
   isError,
+  isDeleting,
+  isSettingPopup,
   handleGoList,
   handleOpenNotice,
+  handleDelete,
+  handleSetPopup,
 }: AdminNoticeDetailViewProps) => {
+  const navigate = useNavigate();
+  const [confirmType, setConfirmType] = useState<'delete' | 'popup' | null>(null);
+
+  const handleConfirm = async () => {
+    if (confirmType === 'delete') {
+      await handleDelete();
+    }
+
+    if (confirmType === 'popup') {
+      await handleSetPopup();
+    }
+
+    setConfirmType(null);
+  };
+
   return (
-    <section className="mx-auto w-full bg-white">
-      <header className="border-b border-[#E6E6E6] px-6 pt-14 pb-12 md:px-10 md:pt-20 md:pb-14">
-        <div className="mx-auto flex max-w-[980px] flex-col items-center text-center">
+    <>
+      <section className="mx-auto w-full bg-white">
+        <header className="border-b border-[#E6E6E6] px-6 pt-14 pb-12 md:px-10 md:pt-20 md:pb-14">
+        <div className="mx-auto flex max-w-[980px] flex-col items-center gap-6 text-center">
+          {isAdmin ? (
+            <div className="flex w-full justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => navigate(`/admin/notices/${notice.id}/edit`)}
+                disabled={!notice.id || isLoading || isDeleting || isSettingPopup}
+                className="inline-flex h-[4.4rem] items-center justify-center rounded-[1.2rem] border border-[#E5E7EB] bg-white px-[1.6rem] text-[1.35rem] font-semibold text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                수정
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmType('delete')}
+                disabled={!notice.id || isLoading || isDeleting || isSettingPopup}
+                className="inline-flex h-[4.4rem] items-center justify-center rounded-[1.2rem] border border-[#FFD6D6] bg-[#FFF5F5] px-[1.6rem] text-[1.35rem] font-semibold text-red-600 transition hover:bg-[#FFECEC] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isDeleting ? '삭제 중...' : '삭제'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmType('popup')}
+                disabled={
+                  !notice.id ||
+                  isLoading ||
+                  isDeleting ||
+                  isSettingPopup ||
+                  notice.isPop
+                }
+                className="inline-flex h-[4.4rem] items-center justify-center rounded-[1.2rem] border border-[#FFE2C0] bg-[#FFF6EC] px-[1.6rem] text-[1.35rem] font-semibold text-[#D86B00] transition hover:bg-[#FFEBD4] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {notice.isPop
+                  ? '팝업 고정됨'
+                  : isSettingPopup
+                    ? '고정 중...'
+                    : '팝업 고정'}
+              </button>
+            </div>
+          ) : null}
+
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            {notice.isPop ? (
+              <span className="inline-flex rounded-full bg-[#FFF1DD] px-4 py-2 text-[1.15rem] font-semibold text-[#D86B00]">
+                POPUP NOTICE
+              </span>
+            ) : null}
+          </div>
+
           <h1 className="max-w-[920px] text-[2rem] leading-[1.35] font-semibold tracking-[-0.04em] text-[#202124] md:text-[3.1rem]">
             {notice.title}
           </h1>
 
-          <div className="mt-5 flex flex-wrap items-center justify-center gap-3 text-[1rem] text-[#8B8F94] md:text-[1.125rem]">
+          <div className="flex flex-wrap items-center justify-center gap-3 text-[1rem] text-[#8B8F94] md:text-[1.125rem]">
             <span>No. {notice.id}</span>
             <span className="h-4 w-px bg-[#D9D9D9]" />
             <Icon name="eye" size={1.6} />
@@ -116,8 +189,25 @@ const AdminNoticeDetailView = ({
             </button>
           </div>
         </div>
-      </div>
-    </section>
+        </div>
+      </section>
+
+      {confirmType ? (
+        <ConfirmModal
+          message={
+            confirmType === 'delete'
+              ? '이 공지사항을 삭제하시겠습니까?'
+              : '이 공지사항을 팝업으로 고정하시겠습니까?'
+          }
+          confirmText={confirmType === 'delete' ? '삭제' : '고정'}
+          cancelText="취소"
+          onCancel={() => setConfirmType(null)}
+          onConfirm={() => {
+            void handleConfirm();
+          }}
+        />
+      ) : null}
+    </>
   );
 };
 

--- a/src/shared/components/admin/notice-detail/notice-content-card.tsx
+++ b/src/shared/components/admin/notice-detail/notice-content-card.tsx
@@ -1,3 +1,5 @@
+import '@toast-ui/editor/dist/toastui-editor.css';
+
 type NoticeContentCardProps = {
   content: string;
 };
@@ -6,7 +8,7 @@ const NoticeContentCard = ({ content }: NoticeContentCardProps) => {
   if (content.trim().startsWith('<')) {
     return (
       <div
-        className="text-[1.14rem] leading-[2] tracking-[-0.02em] text-[#202124] md:text-[1.28rem] [&_h1]:text-[1.5rem] [&_h1]:font-semibold [&_h2]:text-[1.45rem] [&_h2]:font-semibold [&_h3]:text-[1.4rem] [&_h3]:font-semibold [&_h4]:text-[1.3rem] [&_h4]:font-semibold [&_h5]:text-[1.2rem] [&_h5]:font-semibold [&_p]:min-h-[1.4rem] [&_strong]:font-semibold"
+        className="toastui-editor-contents text-[1.14rem] leading-[2] tracking-[-0.02em] text-[#202124] md:text-[1.28rem] [&_blockquote]:my-6 [&_blockquote]:border-l-4 [&_blockquote]:border-[#D6DDFB] [&_blockquote]:bg-[#F7F9FF] [&_blockquote]:px-5 [&_blockquote]:py-4 [&_br]:leading-[2] [&_h1]:mt-8 [&_h1]:text-[1.8rem] [&_h1]:font-semibold [&_h2]:mt-7 [&_h2]:text-[1.6rem] [&_h2]:font-semibold [&_h3]:mt-6 [&_h3]:text-[1.45rem] [&_h3]:font-semibold [&_h4]:mt-5 [&_h4]:text-[1.32rem] [&_h4]:font-semibold [&_h5]:mt-4 [&_h5]:text-[1.2rem] [&_h5]:font-semibold [&_img]:my-6 [&_img]:max-w-full [&_img]:rounded-[1.6rem] [&_img]:border [&_img]:border-[#ECECEC] [&_li]:ml-6 [&_li]:leading-[1.9] [&_li.task-list-item]:ml-0 [&_li.task-list-item]:list-none [&_ol]:my-5 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:min-h-[1.4rem] [&_p]:leading-[1.95] [&_strong]:font-semibold [&_table]:my-6 [&_table]:w-full [&_table]:border-collapse [&_table]:overflow-hidden [&_table]:rounded-[0.4rem] [&_tbody_tr:nth-child(even)]:bg-[#FAFAFA] [&_td]:border [&_td]:border-[#E6E6E6] [&_td]:px-4 [&_td]:py-3 [&_th]:border [&_th]:border-[#D9D9D9] [&_th]:bg-[#F7F9FF] [&_th]:px-4 [&_th]:py-3 [&_th]:font-semibold [&_ul]:my-5 [&_ul]:list-disc [&_ul]:pl-4"
         dangerouslySetInnerHTML={{ __html: content }}
       />
     );

--- a/src/shared/components/notice-detail/notice-detail-container.tsx
+++ b/src/shared/components/notice-detail/notice-detail-container.tsx
@@ -5,6 +5,7 @@ import {
 import AdminNoticeDetailView from '@components/admin/notice-detail/admin-notice-detail-view';
 
 type NoticeDetailContainerProps = {
+  isAdmin?: boolean;
   noticeId?: number;
   notices?: AdminNoticeDetailItem[];
   onBack?: () => void;
@@ -15,7 +16,7 @@ type NoticeDetailContainerProps = {
 const NoticeDetailContainer = (props: NoticeDetailContainerProps) => {
   const detailState = useAdminNoticeDetail(props);
 
-  return <AdminNoticeDetailView {...detailState} />;
+  return <AdminNoticeDetailView isAdmin={props.isAdmin} {...detailState} />;
 };
 
 export default NoticeDetailContainer;

--- a/src/shared/hooks/use-admin-notice-detail.ts
+++ b/src/shared/hooks/use-admin-notice-detail.ts
@@ -1,5 +1,15 @@
-import { useGetNoticeDetail, useGetNotices } from '@apis/telegro';
-import { useMemo } from 'react';
+import {
+  deleteNotice,
+  setPopNotice,
+  useGetNoticeDetail,
+  useGetNotices,
+} from '@apis/telegro';
+import {
+  toastError,
+  toastSuccess,
+} from '@components/common/toast/toast';
+import queryClient from '@libs/query-client';
+import { useMemo, useState } from 'react';
 
 export type AdminNoticeAttachment = {
   id: number;
@@ -17,6 +27,7 @@ export type AdminNoticeDetailItem = {
   relativeLabel?: string;
   author?: string;
   attachments: AdminNoticeAttachment[];
+  isPop: boolean;
 };
 
 export type AdminNoticeSibling = {
@@ -41,6 +52,7 @@ const DEFAULT_NOTICE: AdminNoticeDetailItem = {
   views: 0,
   createdAt: '-',
   attachments: [],
+  isPop: false,
 };
 
 const FALLBACK_SUMMARY = '공지 상세 페이지에서 본문을 확인할 수 있습니다.';
@@ -81,6 +93,14 @@ const toSummary = (content?: string) => {
   return `${plainText.slice(0, 120).trim()}...`;
 };
 
+const invalidateNoticeQueries = () =>
+  queryClient.invalidateQueries({
+    predicate: (query) =>
+      Array.isArray(query.queryKey) &&
+      typeof query.queryKey[0] === 'string' &&
+      query.queryKey[0].startsWith('/notices'),
+  });
+
 export const useAdminNoticeDetail = ({
   noticeId,
   notices,
@@ -88,8 +108,11 @@ export const useAdminNoticeDetail = ({
   onGoList,
   onOpenNotice,
 }: UseAdminNoticeDetailParams) => {
-  const hasValidNoticeId = typeof noticeId === 'number' && Number.isFinite(noticeId);
+  const hasValidNoticeId =
+    typeof noticeId === 'number' && Number.isFinite(noticeId);
   const hasInjectedNotices = Boolean(notices?.length);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isSettingPopup, setIsSettingPopup] = useState(false);
 
   const noticeDetailQuery = useGetNoticeDetail(noticeId ?? 0, {
     query: {
@@ -125,6 +148,7 @@ export const useAdminNoticeDetail = ({
       createdAt: formatNoticeDate(notice.noticeCreateDate),
       author: notice.noticeAuthor?.trim() || '',
       attachments: [],
+      isPop: false,
     }));
   }, [noticeListQuery.data?.data?.notices, notices]);
 
@@ -147,6 +171,7 @@ export const useAdminNoticeDetail = ({
             fileUrl: file.fileUrl?.trim() || '',
           }))
           .filter((file) => Boolean(file.fileUrl)),
+        isPop: Boolean(detail.isPop),
       };
     }
 
@@ -168,6 +193,40 @@ export const useAdminNoticeDetail = ({
       : null;
   const nextNotice = currentIndex > 0 ? resolvedNotices[currentIndex - 1] : null;
 
+  const handleDelete = async () => {
+    if (!notice.id) return;
+
+    setIsDeleting(true);
+
+    try {
+      await deleteNotice(notice.id);
+      await invalidateNoticeQueries();
+      toastSuccess('공지사항을 삭제했습니다.');
+      onGoList?.();
+    } catch {
+      toastError('공지사항 삭제에 실패했습니다.');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleSetPopup = async () => {
+    if (!notice.id || notice.isPop) return;
+
+    setIsSettingPopup(true);
+
+    try {
+      await setPopNotice(notice.id);
+      await invalidateNoticeQueries();
+      await noticeDetailQuery.refetch();
+      toastSuccess('공지사항을 팝업 고정했습니다.');
+    } catch {
+      toastError('공지사항 고정에 실패했습니다.');
+    } finally {
+      setIsSettingPopup(false);
+    }
+  };
+
   return {
     notice,
     prevNotice: prevNotice
@@ -186,8 +245,12 @@ export const useAdminNoticeDetail = ({
       : null,
     isLoading: noticeDetailQuery.isLoading,
     isError: noticeDetailQuery.isError || !hasValidNoticeId,
+    isDeleting,
+    isSettingPopup,
     handleBack: () => onBack?.(),
     handleGoList: () => onGoList?.(),
     handleOpenNotice: (id: number) => onOpenNotice?.(id),
+    handleDelete,
+    handleSetPopup,
   };
 };

--- a/src/shared/layouts/admin-layout.tsx
+++ b/src/shared/layouts/admin-layout.tsx
@@ -6,7 +6,7 @@ const linkClass =
 const AdminLayout = () => {
   return (
     <div className="min-h-screen bg-white">
-      <header className="fixed top-0 z-10 w-full border-b border-[#eee] bg-white px-[3rem] py-[1.6rem]">
+      <header className="fixed top-0 z-50 w-full border-b border-[#eee] bg-white px-[3rem] py-[1.6rem]">
         <nav className="flex gap-[3rem] px-[3rem]">
           <Link to="/admin" className={linkClass}>
             Dashboard

--- a/src/shared/layouts/public-header.tsx
+++ b/src/shared/layouts/public-header.tsx
@@ -5,7 +5,7 @@ const linkClass =
 
 const PublicHeader = () => {
   return (
-    <header className="fixed top-0 z-10 w-full border-b border-[#eee] bg-white px-[3rem] py-[1.6rem]">
+    <header className="fixed top-0 z-50 w-full border-b border-[#eee] bg-white px-[3rem] py-[1.6rem]">
       <nav className="flex gap-[3rem] px-[3rem]">
         <Link to="/" className={linkClass}>
           Home

--- a/src/shared/layouts/public-home-header.tsx
+++ b/src/shared/layouts/public-home-header.tsx
@@ -47,7 +47,7 @@ const PublicHomeHeader = () => {
 
   return (
     <>
-      <header className="relative z-20 px-6 py-4 md:px-12 lg:px-16">
+      <header className="relative z-50 px-6 py-4 md:px-12 lg:px-16">
         <div
           className={[
             'mx-auto flex min-h-[8rem] max-w-[1440px] items-start justify-between py-2 transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] md:min-h-[9.6rem]',

--- a/src/shared/routes/router.tsx
+++ b/src/shared/routes/router.tsx
@@ -91,6 +91,7 @@ export const router = createBrowserRouter([
           { path: 'products/:productId', element: <AdminProductDetail /> },
           { path: 'orders', element: <AdminOrders /> },
           { path: 'notices/create', element: <AdminNoticesNew /> },
+          { path: 'notices/:noticeId/edit', element: <AdminNoticesNew /> },
           { path: 'notices', element: <AdminNotices /> },
           { path: 'notices/:noticeId', element: <AdminNoticeDetail /> },
         ],


### PR DESCRIPTION
Closes #25
                                                                                                                                      
  ## PR 설명                                                                                                                          
                                                                                                                                      
공지사항 기능을 관리자 기준으로 실제 API와 연결했습니다.                                                                            
공지 등록 페이지를 Toast UI Editor 기반으로 구현했고, 첨부파일/본문 이미지 업로드를 presigned URL 방식으로 연동했습니다.            
또한 관리자 공지 상세에서 수정, 삭제, 팝업 고정 기능까지 연결했고, 저장된 HTML이 관리자/일반 공지 상세에서 에디터 미리보기와 유사하게 렌더링되도록 보정했습니다.                                                                                                       
                                                                                                                                      
  ## 해결한 TODO                                                                                                                      
                                                                                                                                      
  - [x] 관리자 공지사항 등록/수정 페이지 구현 및 API 연동                                                                             
  - [x] 관리자 공지 상세 수정/삭제/팝업 고정 기능 연동                                                                                
  - [x] 관리자/일반 공지 상세 HTML 렌더링 및 UI 이슈 보정                                                                             
                                                                                                                                      
  ## 상세 설명                                                                                                                        
                                                                                                                                      
  - 공지 등록/수정                                                                                                                    
    - `src/pages/admin/notices/create.tsx`                                                                                            
    - Toast UI Editor 적용                                                                                                            
    - `createNotice`, `updateNotice`, `getPresignedUrl`, `useGetNoticeDetail` 연동                                                    
    - 첨부파일 업로드 및 본문 이미지 업로드 구현                                                                                      
    - 수정 모드에서 기존 제목/본문/첨부파일 hydrate 처리                                                                              
    - 이미지로만 구성된 본문도 유효한 내용으로 처리되도록 검증 수정                                                                   
                                                                                                                                      
  - 공지 상세 액션                                                                                                                    
    - `src/shared/hooks/use-admin-notice-detail.ts`                                                                                   
    - `deleteNotice`, `setPopNotice` 연동                                                                                             
    - 상세 응답의 `isPop` 상태 반영                                                                                                   
    - 삭제/고정 후 목록/상세/팝업 관련 notice 캐시 invalidate 처리
                                                                                                                                      
    - `src/shared/components/admin/notice-detail/admin-notice-detail-view.tsx`                                                        
    - 관리자일 때만 `수정 / 삭제 / 팝업 고정` 액션 노출                                                                               
    - 브라우저 기본 `confirm` 대신 공용 `ConfirmModal` 사용                                                                           
    - 성공/실패 알림은 공용 `common/toast` 사용                                                                                       
                                                                                                                                      
  - 상세 HTML 렌더링                                                                                                                  
    - `src/shared/components/admin/notice-detail/notice-content-card.tsx`                                                             
    - Toast UI 콘텐츠 스타일 적용                                                                                                     
    - 이미지, 표, 리스트, 체크리스트, 인용문 렌더링 스타일 보강                                                                       
    - 표 radius 축소                                                                                                                  
    - 관리자/일반 상세가 공용 컨테이너를 사용하므로 둘 다 반영됨                                                                      
                                                                                                                                      
  - 라우팅 및 진입점                                                                                                                  
    - `src/shared/routes/router.tsx`
    - `/admin/notices/:noticeId/edit` 경로 추가                                                                                       
                                                                                                                                      
    - `src/pages/admin/notices/notice-detail.tsx`                                                                                     
    - 관리자 상세임을 표시하는 `isAdmin` 플래그 전달                                                                                  
                                                                                                                                      
    - `src/shared/components/notice-detail/notice-detail-container.tsx`                                                               
    - 관리자 전용 액션 렌더링을 위한 `isAdmin` 지원 추가                                                                              
                                                                                                                                      
  - 기타 UI 보정                                                                                                                      
    - `src/pages/admin/notices/notices.tsx`                                                                                           
    - 공지 등록 버튼을 플러스 아이콘 버튼으로 변경                                                                                    
                                                                                                                                      
    - `src/shared/layouts/admin-layout.tsx`                                                                                           
    - `src/shared/layouts/public-header.tsx`                                                                                          
    - `src/shared/layouts/public-home-header.tsx`                                                                                     
    - 헤더 z-index 상향 조정으로 Toast UI 전역 스타일에 헤더가 가려지지 않도록 수정                                                   
                                                                                                                                      
  - 의존성 추가                                                                                                                       
    - `package.json`                                                                                                                  
    - `pnpm-lock.yaml`                                                                                                                
    - `@toast-ui/editor`                                                                                                              
    - `@toast-ui/react-editor`                                                                                                        
    - `@toast-ui/editor-plugin-color-syntax`                                                                                          
    - `tui-color-picker`                                                                                                              
                                                                                                                                      
  ## 공유할 내용                                                                                                                      
                                                                                                                                      
  - 공지 상세 본문 렌더링은 관리자/일반 상세가 같은 공용 상세 컨테이너를 사용하므로 함께 반영됩니다.                                  
  - 삭제/팝업 고정은 현재 관리자 상세에서만 가능하도록 노출했습니다. 

## 📷 Screenshots or Video


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive notice editor with create and edit capabilities for administrators
  * Implemented admin controls to delete notices and manage popup status with confirmation prompts
  * Rich text content editor integration for notice creation and updates

* **Style**
  * Replaced text button with icon-based create button in notice management interface
  * Enhanced visual rendering of notice content with improved typography and layout styling
  * Adjusted header layering for better UI overlap management

* **Chores**
  * Added Toast UI editor dependencies to support rich text editing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->