### PR TITLE
[Fix/#34] 보호 페이지 접근 차단 시 토스트 후 메인 리다이렉트 (All)

### DIFF
--- a/src/shared/routes/admin-guard.tsx
+++ b/src/shared/routes/admin-guard.tsx
@@ -1,14 +1,25 @@
 import { useAtomValue } from 'jotai';
+import { useEffect } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { toastError } from '@components/common/toast/toast';
 import { getStoredUserRole, isAdminAtom } from '@state/session';
+
+const AdminAccessDeniedRedirect = () => {
+  const loc = useLocation();
+
+  useEffect(() => {
+    toastError('관리자 권한이 없습니다.');
+  }, []);
+
+  return <Navigate to="/" replace state={{ from: loc }} />;
+};
 
 const AdminGuard = () => {
   const isAdmin = useAtomValue(isAdminAtom);
-  const loc = useLocation();
   const storedRole = getStoredUserRole();
 
   if (!isAdmin && storedRole !== 'ADMIN') {
-    return <Navigate to="/error" replace state={{ from: loc }} />;
+    return <AdminAccessDeniedRedirect />;
   }
 
   return <Outlet />;

--- a/src/shared/routes/auth-guard.tsx
+++ b/src/shared/routes/auth-guard.tsx
@@ -8,7 +8,7 @@ const AuthGuard = () => {
   const hasStoredToken = Boolean(getStoredAccessToken());
 
   if (!isLoggedIn && !hasStoredToken) {
-    return <Navigate to="/login" replace state={{ from: loc }} />;
+    return <Navigate to="/" replace state={{ from: loc }} />;
   }
 
   return <Outlet />;

--- a/src/shared/routes/auth-guard.tsx
+++ b/src/shared/routes/auth-guard.tsx
@@ -1,14 +1,32 @@
 import { useAtomValue } from 'jotai';
+import { useEffect } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { toastError } from '@components/common/toast/toast';
 import { getStoredAccessToken, isLoggedInAtom } from '@state/session';
+
+const shouldShowLoginToast = (pathname: string) =>
+  pathname === '/app/cart' ||
+  pathname === '/app/my' ||
+  pathname.startsWith('/app/my/');
+
+const AuthRedirect = () => {
+  const loc = useLocation();
+
+  useEffect(() => {
+    if (shouldShowLoginToast(loc.pathname)) {
+      toastError('로그인이 필요합니다.');
+    }
+  }, [loc.pathname]);
+
+  return <Navigate to="/" replace state={{ from: loc }} />;
+};
 
 const AuthGuard = () => {
   const isLoggedIn = useAtomValue(isLoggedInAtom);
-  const loc = useLocation();
   const hasStoredToken = Boolean(getStoredAccessToken());
 
   if (!isLoggedIn && !hasStoredToken) {
-    return <Navigate to="/" replace state={{ from: loc }} />;
+    return <AuthRedirect />;
   }
 
   return <Outlet />;


### PR DESCRIPTION
Closes #34                                                                                                                          
                                                                                                                                      
  ## 🔎 설명                                                                                                                          
                                                                                                                                      
  일반 사용자와 비로그인 사용자가 보호된 페이지에 직접 진입했을 때, 에러 페이지로 빠지지 않고 토스트 메시지를 확인한 뒤 메인 페이지(`/`)로 이동하도록 접근 제어를 정리했습니다.                                                                                           
                                                                                                                                      
  ## 🚀 해결한 TODO                                                                                                                   
                                                                                                                                      
  - [x] 일반 사용자의 관리자 페이지 진입 시 권한 없음 토스트 노출                                                                     
  - [x] 비로그인 상태의 장바구니/마이페이지 진입 시 로그인 안내 토스트 노출                                                           
  - [x] 접근 거부 시 메인 페이지(`/`)로 리다이렉트되도록 가드 로직 수정                                                               
                                                                                                                                      
  ## ✅ 상세 설명💎                                                                                                                   
                                                                                                                                      
  - `AdminGuard`에서 관리자 권한이 없는 사용자가 `/admin` 이하 경로로 진입하면 `관리자 권한이 없습니다.` 토스트를 띄우고 `/`로 리다이 
  렉트되도록 변경했습니다.                                                                                                            
  - `AuthGuard`에서 토큰이 없는 사용자가 `/app/cart`, `/app/my`, `/app/my/*` 경로로 진입하면 `로그인해주세요.` 토스트를 띄우고 `/`로  
  리다이렉트되도록 변경했습니다.                                                                                                      
  - 기존처럼 단순히 라우팅만 막는 방식이 아니라, 사용자에게 왜 이동되었는지 바로 인지할 수 있도록 피드백을 추가했습니다.              
                                                                                                                                      
  ## 💎 새롭게 알게 된 / 공부한 내용                                                                                                  
                                                                                                                                      
  - `Navigate`만 반환하는 가드에서는 사용자 피드백이 없기 때문에, 토스트 같은 사이드이펙트가 필요하면 별도 리다이렉트 컴포넌트로 분리하는 방식이 안전했습니다.                                
                                                                                                                                      
  ## 📷 Screenshots or Video                                                                                                          
                                                                                                                                      
  UI 레이아웃 변경이 아닌 라우팅/토스트 처리 변경이라 별도 스크린샷은 생략했습니다.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced admin access denial with clearer notification messaging and updated redirect flow
  * Added login-required alerts for protected features (cart and profile sections) with improved redirect experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->