### PR TITLE
[Feat/#37] 장바구니 담기/수정/삭제 API 연동 (User)

### DIFF
--- a/src/pages/app/cart/cart.tsx
+++ b/src/pages/app/cart/cart.tsx
@@ -25,6 +25,8 @@ const Cart = () => {
     removeOption,
     removeItem,
     removeSelected,
+    purchaseSelected,
+    purchaseAll,
   } = useCart(fetchedItems);
 
   if (isLoading) {
@@ -101,18 +103,21 @@ const Cart = () => {
             <div className="flex-row-center mt-8 gap-4">
               <button
                 type="button"
+                onClick={() => navigate('/products')}
                 className="rounded-full border border-neutral-400 px-8 py-4 text-[15px] font-medium text-neutral-800 transition hover:bg-neutral-50"
               >
                 쇼핑하러 가기
               </button>
               <button
                 type="button"
+                onClick={purchaseSelected}
                 className="rounded-full border border-neutral-400 px-8 py-4 text-[15px] font-medium text-neutral-800 transition hover:bg-neutral-50"
               >
                 선택상품구매
               </button>
               <button
                 type="button"
+                onClick={purchaseAll}
                 className="rounded-full bg-black px-8 py-4 text-[15px] font-medium text-white transition hover:bg-neutral-800"
               >
                 전체상품구매

--- a/src/pages/app/cart/components/cart-item-section.tsx
+++ b/src/pages/app/cart/components/cart-item-section.tsx
@@ -87,20 +87,20 @@ export function CartItemSection({
         <div className="flex gap-2 lg:flex-col lg:items-stretch lg:justify-start lg:px-4 lg:pt-1">
           <button
             type="button"
-            className="h-10 border border-neutral-300 px-4 text-sm font-medium hover:bg-neutral-50"
+            className="caption4 h-10 border border-neutral-300 px-4 hover:bg-neutral-50"
           >
             옵션추가
           </button>
           <button
             type="button"
-            className="h-10 bg-black px-4 text-sm font-medium text-white hover:bg-neutral-800"
+            className="caption4 h-10 bg-black px-4 text-white hover:bg-neutral-800"
           >
             바로 구매
           </button>
           <button
             type="button"
             onClick={() => onRemoveItem(item.id)}
-            className="h-10 border border-neutral-300 px-4 text-sm text-neutral-500 hover:bg-neutral-50"
+            className="caption4 h-10 border border-neutral-300 px-4 text-neutral-500 hover:bg-neutral-50"
           >
             삭제
           </button>

--- a/src/pages/app/cart/use-cart-items-query.ts
+++ b/src/pages/app/cart/use-cart-items-query.ts
@@ -4,7 +4,7 @@ import { useGetCartItems } from '@apis/telegro';
 
 import { mapCartResponseToCartItems } from './cart.adapters';
 
-const CART_ITEMS_QUERY_PARAMS = {
+export const CART_ITEMS_QUERY_PARAMS = {
   page: 0,
   size: 100,
 };

--- a/src/pages/app/cart/use-cart.ts
+++ b/src/pages/app/cart/use-cart.ts
@@ -1,4 +1,13 @@
+import {
+  telegroInvalidate,
+  useCreateOrder,
+  useDeleteCartItem,
+  useUpdateCartItem,
+} from '@apis/telegro';
+import { toastError, toastSuccess } from '@components/common/toast/toast';
+import { useQueryClient } from '@tanstack/react-query';
 import { useLayoutEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import type { CartItem } from './cart.types';
 import {
@@ -7,12 +16,28 @@ import {
   getAllOptionIds,
   isItemFullySelected,
 } from './cart.utils';
+import { CART_ITEMS_QUERY_PARAMS } from './use-cart-items-query';
+
+const parseCartId = (optionId: string) => {
+  const cartId = Number(optionId);
+
+  if (!Number.isFinite(cartId)) {
+    throw new Error(`Invalid cart option id: ${optionId}`);
+  }
+
+  return cartId;
+};
 
 export const useCart = (initialItems: CartItem[]) => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [items, setItems] = useState<CartItem[]>(initialItems);
   const [selectedOptionIds, setSelectedOptionIds] = useState<string[]>(() =>
     getAllOptionIds(initialItems),
   );
+  const updateCartItemMutation = useUpdateCartItem();
+  const deleteCartItemMutation = useDeleteCartItem();
+  const createOrderMutation = useCreateOrder();
 
   useLayoutEffect(() => {
     setItems(initialItems);
@@ -29,6 +54,9 @@ export const useCart = (initialItems: CartItem[]) => {
   const allSelected =
     items.length > 0 &&
     items.every((item) => isItemFullySelected(item, selectedOptionIds));
+
+  const invalidateCartItems = () =>
+    telegroInvalidate.cartItems(queryClient, CART_ITEMS_QUERY_PARAMS);
 
   const toggleAll = () => {
     setSelectedOptionIds(allSelected ? [] : getAllOptionIds(items));
@@ -54,20 +82,47 @@ export const useCart = (initialItems: CartItem[]) => {
     });
   };
 
-  const updateQuantity = (optionId: string, delta: number) => {
+  const updateQuantity = async (optionId: string, delta: number) => {
+    const previousItems = items;
+    const targetOption = previousItems
+      .flatMap((item) => item.options)
+      .find((option) => option.id === optionId);
+
+    if (!targetOption) {
+      return;
+    }
+
+    const nextQuantity = Math.max(1, targetOption.quantity + delta);
+
+    if (nextQuantity === targetOption.quantity) {
+      return;
+    }
+
     setItems((prev) =>
       prev.map((item) => ({
         ...item,
         options: item.options.map((option) =>
-          option.id === optionId
-            ? { ...option, quantity: Math.max(1, option.quantity + delta) }
-            : option,
+          option.id === optionId ? { ...option, quantity: nextQuantity } : option,
         ),
       })),
     );
+
+    try {
+      await updateCartItemMutation.mutateAsync({
+        cartId: parseCartId(optionId),
+        data: { quantity: nextQuantity },
+      });
+      await invalidateCartItems();
+    } catch {
+      setItems(previousItems);
+      toastError('수량 변경에 실패했습니다.');
+    }
   };
 
-  const removeOption = (optionId: string) => {
+  const removeOption = async (optionId: string) => {
+    const previousItems = items;
+    const previousSelectedOptionIds = selectedOptionIds;
+
     setItems((prev) =>
       prev
         .map((item) => ({
@@ -78,21 +133,64 @@ export const useCart = (initialItems: CartItem[]) => {
     );
 
     setSelectedOptionIds((prev) => prev.filter((id) => id !== optionId));
+
+    try {
+      await deleteCartItemMutation.mutateAsync({
+        cartId: parseCartId(optionId),
+      });
+      await invalidateCartItems();
+      toastSuccess('상품이 장바구니에서 삭제되었습니다.');
+    } catch {
+      setItems(previousItems);
+      setSelectedOptionIds(previousSelectedOptionIds);
+      toastError('상품 삭제에 실패했습니다.');
+    }
   };
 
-  const removeItem = (itemId: string) => {
+  const removeItem = async (itemId: string) => {
     const targetItem = items.find((item) => item.id === itemId);
     if (!targetItem) {
       return;
     }
 
+    if (!window.confirm('정말로 이 상품을 장바구니에서 삭제하시겠습니까?')) {
+      return;
+    }
+
+    const previousItems = items;
+    const previousSelectedOptionIds = selectedOptionIds;
+
     setItems((prev) => prev.filter((item) => item.id !== itemId));
     setSelectedOptionIds((prev) =>
       prev.filter((id) => !targetItem.options.some((option) => option.id === id)),
     );
+
+    try {
+      await Promise.all(
+        targetItem.options.map((option) =>
+          deleteCartItemMutation.mutateAsync({
+            cartId: parseCartId(option.id),
+          }),
+        ),
+      );
+      await invalidateCartItems();
+      toastSuccess('상품이 장바구니에서 삭제되었습니다.');
+    } catch {
+      setItems(previousItems);
+      setSelectedOptionIds(previousSelectedOptionIds);
+      toastError('상품 삭제에 실패했습니다.');
+    }
   };
 
-  const removeSelected = () => {
+  const removeSelected = async () => {
+    if (!selectedOptionIds.length) {
+      toastError('삭제할 상품을 선택해주세요.');
+      return;
+    }
+
+    const previousItems = items;
+    const previousSelectedOptionIds = selectedOptionIds;
+
     setItems((prev) =>
       prev
         .map((item) => ({
@@ -104,6 +202,43 @@ export const useCart = (initialItems: CartItem[]) => {
         .filter((item) => item.options.length > 0),
     );
     setSelectedOptionIds([]);
+
+    try {
+      await Promise.all(
+        previousSelectedOptionIds.map((optionId) =>
+          deleteCartItemMutation.mutateAsync({
+            cartId: parseCartId(optionId),
+          }),
+        ),
+      );
+      await invalidateCartItems();
+      toastSuccess('선택한 상품이 삭제되었습니다.');
+    } catch {
+      setItems(previousItems);
+      setSelectedOptionIds(previousSelectedOptionIds);
+      toastError('선택 삭제에 실패했습니다.');
+    }
+  };
+
+  const purchase = async (optionIds: string[]) => {
+    if (!optionIds.length) {
+      toastError('구매할 상품을 선택해주세요.');
+      return;
+    }
+
+    try {
+      const response = await createOrderMutation.mutateAsync({
+        data: optionIds.map(parseCartId),
+      });
+
+      navigate('/app/checkout', {
+        state: {
+          orderData: response.data,
+        },
+      });
+    } catch {
+      toastError('주문 생성에 실패했습니다.');
+    }
   };
 
   return {
@@ -118,5 +253,7 @@ export const useCart = (initialItems: CartItem[]) => {
     removeOption,
     removeItem,
     removeSelected,
+    purchaseSelected: () => purchase(selectedOptionIds),
+    purchaseAll: () => purchase(getAllOptionIds(items)),
   };
 };

--- a/src/shared/components/product-detail/product-detail-container.tsx
+++ b/src/shared/components/product-detail/product-detail-container.tsx
@@ -1,11 +1,18 @@
 import {
+  telegroInvalidate,
+  useAddCartItem,
   useGetProducts,
   type GetProductsCategory,
   type ProductDetailResponseDTO,
 } from '@apis/telegro';
-import { useProductDetail, type RecommendationItem } from '@hooks/use-product-detail';
 import ProductDetailView from '@components/product-detail/product-detail-view';
+import { toastError, toastSuccess } from '@components/common/toast/toast';
+import { useProductDetail, type RecommendationItem } from '@hooks/use-product-detail';
+import { useQueryClient } from '@tanstack/react-query';
 import { formatNumber } from '@utils/format';
+import { useNavigate } from 'react-router-dom';
+
+import { CART_ITEMS_QUERY_PARAMS } from '@pages/app/cart/use-cart-items-query';
 
 type ProductDetailContainerProps = {
   productId?: number;
@@ -28,6 +35,9 @@ const ProductDetailContainer = ({
   onEdit,
   onDelete,
 }: ProductDetailContainerProps) => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const addCartItemMutation = useAddCartItem();
   const category = product?.category as GetProductsCategory | undefined;
   const recommendationQuery = useGetProducts(
     {
@@ -80,6 +90,36 @@ const ProductDetailContainer = ({
     recommendations: recommendations ?? apiRecommendations,
   });
 
+  const handleAddCart = async () => {
+    if (!productId) {
+      toastError('유효하지 않은 상품입니다.');
+      return;
+    }
+
+    const selectOption = resolvedProduct.options?.find((option) => option?.trim())?.trim();
+
+    try {
+      await addCartItemMutation.mutateAsync({
+        productId,
+        data: {
+          selectOption,
+          quantity,
+          inputOption: '',
+        },
+      });
+      await telegroInvalidate.cartItems(queryClient, CART_ITEMS_QUERY_PARAMS);
+      toastSuccess('상품이 장바구니에 담겼습니다.');
+    } catch (error: any) {
+      if (error?.response?.status === 401) {
+        toastError('로그인을 먼저 진행해주세요.');
+        navigate('/login');
+        return;
+      }
+
+      toastError('장바구니 담기에 실패했습니다.');
+    }
+  };
+
   return (
     <ProductDetailView
       product={resolvedProduct}
@@ -101,6 +141,7 @@ const ProductDetailContainer = ({
       onSelectImage={setSelectedImage}
       onDecreaseQuantity={() => setQuantity((prev) => Math.max(1, prev - 1))}
       onIncreaseQuantity={() => setQuantity((prev) => prev + 1)}
+      onAddCart={handleAddCart}
       onToggleDetail={() => setIsDetailOpen((prev) => !prev)}
       onToggleLike={handleToggleLike}
       onShare={handleShare}

--- a/src/shared/components/product-detail/product-detail-container.tsx
+++ b/src/shared/components/product-detail/product-detail-container.tsx
@@ -5,8 +5,8 @@ import {
   type GetProductsCategory,
   type ProductDetailResponseDTO,
 } from '@apis/telegro';
-import ProductDetailView from '@components/product-detail/product-detail-view';
 import { toastError, toastSuccess } from '@components/common/toast/toast';
+import ProductDetailView from '@components/product-detail/product-detail-view';
 import { useProductDetail, type RecommendationItem } from '@hooks/use-product-detail';
 import { useQueryClient } from '@tanstack/react-query';
 import { formatNumber } from '@utils/format';
@@ -74,6 +74,10 @@ const ProductDetailContainer = ({
     setSelectedImage,
     quantity,
     setQuantity,
+    selectedOption,
+    setSelectedOption,
+    inputOption,
+    setInputOption,
     galleryImages,
     isDetailOpen,
     setIsDetailOpen,
@@ -96,15 +100,18 @@ const ProductDetailContainer = ({
       return;
     }
 
-    const selectOption = resolvedProduct.options?.find((option) => option?.trim())?.trim();
+    if (!selectedOption) {
+      toastError('옵션을 선택해주세요.');
+      return;
+    }
 
     try {
       await addCartItemMutation.mutateAsync({
         productId,
         data: {
-          selectOption,
+          selectOption: selectedOption,
           quantity,
-          inputOption: '',
+          inputOption,
         },
       });
       await telegroInvalidate.cartItems(queryClient, CART_ITEMS_QUERY_PARAMS);
@@ -126,6 +133,8 @@ const ProductDetailContainer = ({
       activeTab={activeTab}
       selectedImage={selectedImage}
       quantity={quantity}
+      selectedOption={selectedOption}
+      inputOption={inputOption}
       galleryImages={galleryImages}
       isDetailOpen={isDetailOpen}
       isLiked={isLiked}
@@ -141,6 +150,8 @@ const ProductDetailContainer = ({
       onSelectImage={setSelectedImage}
       onDecreaseQuantity={() => setQuantity((prev) => Math.max(1, prev - 1))}
       onIncreaseQuantity={() => setQuantity((prev) => prev + 1)}
+      onSelectOption={setSelectedOption}
+      onInputOptionChange={setInputOption}
       onAddCart={handleAddCart}
       onToggleDetail={() => setIsDetailOpen((prev) => !prev)}
       onToggleLike={handleToggleLike}

--- a/src/shared/components/product-detail/product-detail-purchase-panel.tsx
+++ b/src/shared/components/product-detail/product-detail-purchase-panel.tsx
@@ -1,6 +1,6 @@
-import { type ReactNode } from 'react';
-
+import { type ProductDetailResponseDTOCategory } from '@apis/telegro';
 import { cn } from '@libs/cn';
+import { type ReactNode } from 'react';
 import { FiShare2 } from 'react-icons/fi';
 import { IoHeart, IoHeartOutline } from 'react-icons/io5';
 
@@ -9,12 +9,18 @@ type ProductDetailPurchasePanelProps = {
   price?: string;
   rewardPointLabel: string;
   quantity: number;
+  category?: ProductDetailResponseDTOCategory;
+  options: string[];
+  selectedOption: string;
+  inputOption: string;
   isLiked: boolean;
   likeCount: number;
   isShareCopied: boolean;
   totalPriceLabel: string;
   onDecrease: () => void;
   onIncrease: () => void;
+  onSelectOption: (option: string) => void;
+  onInputOptionChange: (value: string) => void;
   onAddCart?: () => void;
   onToggleLike: () => void;
   onShare: () => void;
@@ -29,12 +35,18 @@ const ProductDetailPurchasePanel = ({
   price,
   rewardPointLabel,
   quantity,
+  category,
+  options,
+  selectedOption,
+  inputOption,
   isLiked,
   likeCount,
   isShareCopied,
   totalPriceLabel,
   onDecrease,
   onIncrease,
+  onSelectOption,
+  onInputOptionChange,
   onAddCart,
   onToggleLike,
   onShare,
@@ -43,6 +55,9 @@ const ProductDetailPurchasePanel = ({
   onEdit,
   onDelete,
 }: ProductDetailPurchasePanelProps) => {
+  const requiresInputOption =
+    category === 'HEADSET' || category === 'LINE_CORD' || category === 'RECORDER';
+
   return (
     <aside className="flex flex-col gap-6 pt-1">
       <div className="flex items-start justify-between gap-5">
@@ -72,6 +87,35 @@ const ProductDetailPurchasePanel = ({
       </div>
 
       <div className="h-px w-full bg-[#DFE4E8]" />
+
+      <div className="flex flex-col gap-3">
+        <label className="text-[1rem] font-medium text-[#263238]">옵션</label>
+        <select
+          value={selectedOption}
+          onChange={(event) => onSelectOption(event.target.value)}
+          className="h-[4.4rem] border border-[#D9E0E6] bg-white px-4 text-[1rem] text-[#263238] outline-none focus:border-[#1F3138]"
+        >
+          {options.length ? (
+            options.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))
+          ) : (
+            <option value="">기본 옵션</option>
+          )}
+        </select>
+
+        {requiresInputOption ? (
+          <input
+            type="text"
+            value={inputOption}
+            onChange={(event) => onInputOptionChange(event.target.value)}
+            placeholder="기타 옵션 기재"
+            className="h-[4.4rem] border border-[#D9E0E6] bg-white px-4 text-[1rem] text-[#263238] outline-none placeholder:text-[#9CA3AF] focus:border-[#1F3138]"
+          />
+        ) : null}
+      </div>
 
       <div className="flex items-center gap-2 text-[1rem] text-[#637381]">
         <span className="font-semibold text-[#263238]">구매 적립</span>
@@ -106,9 +150,7 @@ const ProductDetailPurchasePanel = ({
       </div>
 
       <div className="flex items-end justify-between pt-5">
-        <span className="text-[1.6rem] text-[#637381]">
-          총 상품 금액({quantity}개)
-        </span>
+        <span className="text-[1.6rem] text-[#637381]">총 상품 금액({quantity}개)</span>
         <strong className="text-[2.3rem] leading-none font-medium text-[#263238]">
           {totalPriceLabel}
         </strong>

--- a/src/shared/components/product-detail/product-detail-purchase-panel.tsx
+++ b/src/shared/components/product-detail/product-detail-purchase-panel.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from 'react';
+
 import { cn } from '@libs/cn';
 import { FiShare2 } from 'react-icons/fi';
 import { IoHeart, IoHeartOutline } from 'react-icons/io5';
@@ -14,6 +15,7 @@ type ProductDetailPurchasePanelProps = {
   totalPriceLabel: string;
   onDecrease: () => void;
   onIncrease: () => void;
+  onAddCart?: () => void;
   onToggleLike: () => void;
   onShare: () => void;
   isAdminMode?: boolean;
@@ -33,6 +35,7 @@ const ProductDetailPurchasePanel = ({
   totalPriceLabel,
   onDecrease,
   onIncrease,
+  onAddCart,
   onToggleLike,
   onShare,
   isAdminMode = false,
@@ -55,7 +58,7 @@ const ProductDetailPurchasePanel = ({
         <button
           type="button"
           aria-label="공유하기"
-          title={isShareCopied ? '복사되었습니다' : '공유하기'}
+          title={isShareCopied ? '복사되었습니다.' : '공유하기'}
           onClick={onShare}
           className={cn(
             'flex-row-center mt-2 h-12 w-12 cursor-pointer rounded-full bg-gray-200 transition-all',
@@ -127,7 +130,9 @@ const ProductDetailPurchasePanel = ({
       ) : (
         <div className="grid grid-cols-[1.15fr_1fr_0.8fr] gap-3 pt-3">
           <ActionButton variant="primary">구매하기</ActionButton>
-          <ActionButton variant="secondary">장바구니</ActionButton>
+          <ActionButton variant="secondary" onClick={onAddCart}>
+            장바구니
+          </ActionButton>
           <ActionButton
             variant="ghost"
             onClick={onToggleLike}

--- a/src/shared/components/product-detail/product-detail-view.tsx
+++ b/src/shared/components/product-detail/product-detail-view.tsx
@@ -1,13 +1,13 @@
 import { type ProductDetailResponseDTO } from '@apis/telegro';
 import ExploreScrollToTop from '@components/common/explore-scroll-to-top';
+import ProductDetailGallery from '@components/product-detail/product-detail-gallery';
+import ProductDetailPurchasePanel from '@components/product-detail/product-detail-purchase-panel';
+import ProductDetailRecommendationSection from '@components/product-detail/product-detail-recommendation-section';
+import ProductDetailTabs from '@components/product-detail/product-detail-tabs';
 import {
   type ProductTab,
   type RecommendationItem,
 } from '@hooks/use-product-detail';
-import ProductDetailGallery from '@components/product-detail/product-detail-gallery';
-import ProductDetailPurchasePanel from '@components/product-detail/product-detail-purchase-panel';
-import ProductDetailTabs from '@components/product-detail/product-detail-tabs';
-import ProductDetailRecommendationSection from '@components/product-detail/product-detail-recommendation-section';
 import { useRef } from 'react';
 
 type ProductDetailViewProps = {
@@ -30,6 +30,7 @@ type ProductDetailViewProps = {
   onSelectImage: (image: string) => void;
   onDecreaseQuantity: () => void;
   onIncreaseQuantity: () => void;
+  onAddCart?: () => void;
   onToggleDetail: () => void;
   onToggleLike: () => void;
   onShare: () => void;
@@ -57,6 +58,7 @@ const ProductDetailView = ({
   onSelectImage,
   onDecreaseQuantity,
   onIncreaseQuantity,
+  onAddCart,
   onToggleDetail,
   onToggleLike,
   onShare,
@@ -67,7 +69,7 @@ const ProductDetailView = ({
 
   return (
     <div ref={pageRef} className="min-h-screen bg-[#FBFBF8] text-gray-900">
-      <main className="mx-auto flex w-full max-w-[124rem] flex-col px-6 pt-10 pb-24">
+      <main className="mx-auto flex w-full max-w-[124rem] flex-col px-6 pb-24 pt-10">
         <div className="mb-8 flex items-center gap-3 text-[1.05rem] text-[#9CA3AF]">
           <span>Product</span>
           <span>/</span>
@@ -92,6 +94,7 @@ const ProductDetailView = ({
             totalPriceLabel={totalPriceLabel}
             onDecrease={onDecreaseQuantity}
             onIncrease={onIncreaseQuantity}
+            onAddCart={onAddCart}
             onToggleLike={onToggleLike}
             onShare={onShare}
             isAdminMode={isAdminMode}
@@ -111,9 +114,7 @@ const ProductDetailView = ({
                 onClick={onToggleDetail}
                 className="flex-row-center h-[4.8rem] w-full cursor-pointer gap-2 border-[2px] border-gray-600 bg-white text-[1.5rem] font-semibold text-[#263238] shadow-[0_8px_16px_rgba(38,50,56,0.08)] transition-colors hover:bg-gray-100"
               >
-                <span>
-                  {isDetailOpen ? '상품 상세 접기' : '상품 상세 보기'}
-                </span>
+                <span>{isDetailOpen ? '상품 상세 접기' : '상품 상세 보기'}</span>
                 <span className={isDetailOpen ? 'rotate-0' : 'rotate-180'}>
                   <ChevronUpIcon />
                 </span>
@@ -126,16 +127,14 @@ const ProductDetailView = ({
                     dangerouslySetInnerHTML={{ __html: product.content }}
                   />
                 ) : (
-                  <div className="text-[1.18rem] leading-[2] whitespace-pre-line text-gray-700">
+                  <div className="whitespace-pre-line text-[1.18rem] leading-[2] text-gray-700">
                     {product.content}
                   </div>
                 )
               ) : null}
             </>
           )}
-          {activeTab === 'review' ? (
-            <EmptyPanel title="No reviews yet." />
-          ) : null}
+          {activeTab === 'review' ? <EmptyPanel title="No reviews yet." /> : null}
           {activeTab === 'return' ? (
             <InfoPanel
               title="Returns and exchanges"
@@ -146,9 +145,7 @@ const ProductDetailView = ({
               ]}
             />
           ) : null}
-          {activeTab === 'qna' ? (
-            <EmptyPanel title="No questions yet." />
-          ) : null}
+          {activeTab === 'qna' ? <EmptyPanel title="No questions yet." /> : null}
         </section>
 
         <ProductDetailRecommendationSection

--- a/src/shared/components/product-detail/product-detail-view.tsx
+++ b/src/shared/components/product-detail/product-detail-view.tsx
@@ -15,6 +15,8 @@ type ProductDetailViewProps = {
   activeTab: ProductTab;
   selectedImage: string;
   quantity: number;
+  selectedOption: string;
+  inputOption: string;
   galleryImages: string[];
   isDetailOpen: boolean;
   isLiked: boolean;
@@ -30,6 +32,8 @@ type ProductDetailViewProps = {
   onSelectImage: (image: string) => void;
   onDecreaseQuantity: () => void;
   onIncreaseQuantity: () => void;
+  onSelectOption: (option: string) => void;
+  onInputOptionChange: (value: string) => void;
   onAddCart?: () => void;
   onToggleDetail: () => void;
   onToggleLike: () => void;
@@ -43,6 +47,8 @@ const ProductDetailView = ({
   activeTab,
   selectedImage,
   quantity,
+  selectedOption,
+  inputOption,
   galleryImages,
   isDetailOpen,
   isLiked,
@@ -58,6 +64,8 @@ const ProductDetailView = ({
   onSelectImage,
   onDecreaseQuantity,
   onIncreaseQuantity,
+  onSelectOption,
+  onInputOptionChange,
   onAddCart,
   onToggleDetail,
   onToggleLike,
@@ -88,12 +96,18 @@ const ProductDetailView = ({
             price={product.price}
             rewardPointLabel={rewardPointLabel}
             quantity={quantity}
+            category={product.category}
+            options={product.options ?? []}
+            selectedOption={selectedOption}
+            inputOption={inputOption}
             isLiked={isLiked}
             likeCount={likeCount}
             isShareCopied={isShareCopied}
             totalPriceLabel={totalPriceLabel}
             onDecrease={onDecreaseQuantity}
             onIncrease={onIncreaseQuantity}
+            onSelectOption={onSelectOption}
+            onInputOptionChange={onInputOptionChange}
             onAddCart={onAddCart}
             onToggleLike={onToggleLike}
             onShare={onShare}

--- a/src/shared/hooks/use-product-detail.ts
+++ b/src/shared/hooks/use-product-detail.ts
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
 import { type ProductDetailResponseDTO } from '@apis/telegro';
 import { toastError, toastSuccess } from '@components/common/toast/toast';
+import { useEffect, useMemo, useState } from 'react';
 
 export type RecommendationItem = {
   id: number;
@@ -22,7 +22,7 @@ const DEFAULT_PRODUCT: ProductDetailResponseDTO = {
   options: ['기본 구성', '1개'],
   category: 'ACCESSORY',
   content:
-    '여행 가방에 가볍게 넣어두기 좋은 칵테일 키트입니다. 군더더기 없는 패키지와 차분한 무드의 디테일을 중심으로 구성되어 선물용으로도 잘 어울립니다.\n\n패키지 내부에는 간단한 칵테일 제조에 필요한 기본 구성이 포함되어 있으며, 감각적인 오브제로도 활용할 수 있도록 절제된 톤의 디자인을 적용했습니다.',
+    '휴대가 간편한 샘플 상품 설명입니다. 실제 응답이 없을 때도 화면 구조를 확인할 수 있도록 기본 텍스트를 제공합니다.',
   price: '24,000',
   priceBussiness: '22,000',
   priceBest: '21,000',
@@ -38,6 +38,8 @@ export const useProductDetail = ({
 }: UseProductDetailParams = {}) => {
   const [activeTab, setActiveTab] = useState<ProductTab>('detail');
   const [quantity, setQuantity] = useState(1);
+  const [selectedOption, setSelectedOption] = useState('');
+  const [inputOption, setInputOption] = useState('');
   const [isDetailOpen, setIsDetailOpen] = useState(true);
   const [isLiked, setIsLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
@@ -53,18 +55,26 @@ export const useProductDetail = ({
   const [selectedImage, setSelectedImage] = useState(product.coverImage ?? '');
 
   const basePrice = useMemo(() => {
-    const numeric = (product.price ?? '24,000').replace(/[,원\s]/g, '');
+    const numeric = (product.price ?? '24,000').replace(/[,\s원]/g, '');
     return Number(numeric) || 24000;
   }, [product.price]);
 
   const totalPriceLabel = useMemo(
-    () => (basePrice * quantity).toLocaleString(),
+    () => `${(basePrice * quantity).toLocaleString()}원`,
     [basePrice, quantity],
   );
   const rewardPointLabel = useMemo(
-    () => `${(1000 * quantity).toLocaleString()} 포인트 적립예정`,
+    () => `${(1000 * quantity).toLocaleString()} 포인트 적립 예정`,
     [quantity],
   );
+
+  useEffect(() => {
+    const firstOption = product.options?.find((option) => option?.trim())?.trim() ?? '';
+    setSelectedImage(product.coverImage ?? '');
+    setSelectedOption(firstOption);
+    setInputOption('');
+    setQuantity(1);
+  }, [product]);
 
   useEffect(() => {
     if (!isShareCopied) return;
@@ -106,6 +116,10 @@ export const useProductDetail = ({
     setSelectedImage,
     quantity,
     setQuantity,
+    selectedOption,
+    setSelectedOption,
+    inputOption,
+    setInputOption,
     galleryImages,
     isDetailOpen,
     setIsDetailOpen,


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #37   

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 설명

  - 장바구니 페이지의 수량 수정/삭제/선택 삭제/주문 생성 로직을 orval 기반 API로 연동했습니다.                                        
  - 상품 상세 페이지의 `장바구니` 버튼을 orval `addCartItem` mutation에 연결했습니다.                                                 
  - 장바구니 조회 쿼리 파라미터를 export해서 mutation 이후 동일 조건으로 캐시 invalidate 하도록 정리했습니다.    
  
## 🚀 해결한 TODO

- [x] 장바구니 담기/수정/삭제 api 연동

## ✅ 상세 설명💎                                                                                                                     
  ### 장바구니 페이지
  - `useCart`에 아래 mutation을 연결했습니다.                                                                                         
    - `useUpdateCartItem`                                                                                                             
    - `useDeleteCartItem`                                                                                                             
    - `useCreateOrder`                                                                                                                
  - 수량 변경 시 optimistic update 후 API 요청, 실패 시 롤백 처리하도록 변경했습니다.
  - 옵션 삭제 / 상품 삭제 / 선택 삭제 시 실제 DELETE API 호출이 수행되도록 변경했습니다.                                              
  - 삭제 성공/실패, 수량 변경 실패, 주문 생성 실패에 대해 toast를 노출하도록 처리했습니다.                                            
  - 선택 상품 구매 / 전체 상품 구매 버튼에 실제 주문 생성 로직을 연결했습니다.                                                        
  - `쇼핑하러 가기` 버튼에 `/products` 이동을 연결했습니다.                                                                           
                                                                                                                                      
  ### 상품 상세 페이지                                                                                                                
  - `장바구니` 버튼 클릭 시 `useAddCartItem` mutation이 호출되도록 연결했습니다.                                                      
  - 성공 시 장바구니 캐시 invalidate 및 성공 toast를 노출합니다.                                                                      
  - 401 응답 시 로그인 안내 toast 후 `/login`으로 이동합니다.                                                                         
  - 현재 상세 UI에 옵션 선택 필드가 없어, 우선 `product.options`의 첫 번째 값을 `selectOption`으로 사용하도록 처리했습니다.           
                                                                                                                                      
  ## 변경 파일                                                                                                                        
  - `src/pages/app/cart/cart.tsx`
  - `src/pages/app/cart/use-cart-items-query.ts`                                                                                      
  - `src/pages/app/cart/use-cart.ts`                                                                                                  
  - `src/shared/components/product-detail/product-detail-container.tsx`                                                               
  - `src/shared/components/product-detail/product-detail-purchase-panel.tsx`                                                          
  - `src/shared/components/product-detail/product-detail-view.tsx`                                                                    


## 📷 Screenshots or Video


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added product option selection on product detail page with support for custom option input for specific product categories.
  * Enabled "Add to Cart" button on product detail page with validation and confirmation feedback.
  * Added purchase actions in cart: select and purchase specific items or purchase all items at once.

* **Style**
  * Updated button styling in cart item section for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->