### PR TITLE
[Feat/#47] 공지사항 리스트 content 텍스트 미리보기 적용 (All)

### DIFF
--- a/src/shared/components/admin/notice-detail/admin-notice-detail-view.tsx
+++ b/src/shared/components/admin/notice-detail/admin-notice-detail-view.tsx
@@ -115,12 +115,6 @@ const AdminNoticeDetailView = ({
           <NoticeHeroGraphic />
 
           <article className="flex flex-col gap-8 text-[#202124]">
-            {notice.summary ? (
-              <p className="text-[1.2rem] leading-[1.95] font-medium tracking-[-0.02em] text-[#5B74F7] md:text-[1.35rem]">
-                {notice.summary}
-              </p>
-            ) : null}
-
             {isLoading ? (
               <LoadingPanel
                 className="min-h-[28rem] rounded-[1.6rem] bg-[#FBFBF8]"

--- a/src/shared/hooks/use-admin-notice-detail.ts
+++ b/src/shared/hooks/use-admin-notice-detail.ts
@@ -10,6 +10,7 @@ import {
 } from '@components/common/toast/toast';
 import queryClient from '@libs/query-client';
 import { useMemo, useState } from 'react';
+import { stripHtmlToText } from '@utils/html';
 
 export type AdminNoticeAttachment = {
   id: number;
@@ -72,15 +73,8 @@ const formatNoticeDate = (value?: string) => {
   return `${year}.${month}.${day}`;
 };
 
-const stripHtml = (value?: string) =>
-  (value ?? '')
-    .replace(/<[^>]*>/g, ' ')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-
 const toSummary = (content?: string) => {
-  const plainText = stripHtml(content);
+  const plainText = stripHtmlToText(content);
 
   if (!plainText) {
     return FALLBACK_SUMMARY;

--- a/src/shared/hooks/use-admin-notice-detail.ts
+++ b/src/shared/hooks/use-admin-notice-detail.ts
@@ -10,7 +10,6 @@ import {
 } from '@components/common/toast/toast';
 import queryClient from '@libs/query-client';
 import { useMemo, useState } from 'react';
-import { stripHtmlToText } from '@utils/html';
 
 export type AdminNoticeAttachment = {
   id: number;
@@ -73,8 +72,15 @@ const formatNoticeDate = (value?: string) => {
   return `${year}.${month}.${day}`;
 };
 
+const stripHtml = (value?: string) =>
+  (value ?? '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
 const toSummary = (content?: string) => {
-  const plainText = stripHtmlToText(content);
+  const plainText = stripHtml(content);
 
   if (!plainText) {
     return FALLBACK_SUMMARY;

--- a/src/shared/hooks/use-notice-section.ts
+++ b/src/shared/hooks/use-notice-section.ts
@@ -18,9 +18,8 @@ type UseNoticeSectionParams = {
 };
 
 const DEFAULT_PAGE_SIZE = 2;
-
 const FALLBACK_PREVIEW =
-  '\uACF5\uC9C0 \uC0C1\uC138 \uD398\uC774\uC9C0\uC5D0\uC11C \uBCF8\uBB38\uC744 \uD655\uC778\uD560 \uC218 \uC788\uC2B5\uB2C8\uB2E4.';
+  '공지 상세 페이지에서 자세한 내용을 확인할 수 있습니다.';
 
 type NoticeListItemWithContext = {
   context?: string | null;

--- a/src/shared/hooks/use-notice-section.ts
+++ b/src/shared/hooks/use-notice-section.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useGetNotices } from '@apis/telegro';
+import { stripHtmlToText } from '@utils/html';
 
 export type NoticeItem = {
   id: number;
@@ -20,6 +21,10 @@ const DEFAULT_PAGE_SIZE = 2;
 
 const FALLBACK_PREVIEW =
   '\uACF5\uC9C0 \uC0C1\uC138 \uD398\uC774\uC9C0\uC5D0\uC11C \uBCF8\uBB38\uC744 \uD655\uC778\uD560 \uC218 \uC788\uC2B5\uB2C8\uB2E4.';
+
+type NoticeListItemWithContext = {
+  context?: string | null;
+};
 
 const formatNoticeDate = (value?: string) => {
   if (!value) return '-';
@@ -57,18 +62,21 @@ export function useNoticeSection({
       return notices;
     }
 
-    return (noticeQuery.data?.data?.notices ?? []).map((notice) => ({
-      id: notice.id ?? 0,
-      title:
-        notice.noticeTitle?.trim() ||
-        '\uC81C\uBAA9 \uC5C6\uB294 \uACF5\uC9C0\uC0AC\uD56D',
-      preview:
-        notice.noticeFileName?.trim() ||
-        notice.noticeAuthor?.trim() ||
-        FALLBACK_PREVIEW,
-      views: notice.viewCount ?? 0,
-      dateLabel: formatNoticeDate(notice.noticeCreateDate),
-    }));
+    return (noticeQuery.data?.data?.notices ?? []).map((notice) => {
+      const plainTextPreview = stripHtmlToText(
+        (notice as typeof notice & NoticeListItemWithContext).context ?? '',
+      );
+
+      return {
+        id: notice.id ?? 0,
+        title:
+          notice.noticeTitle?.trim() ||
+          '\uC81C\uBAA9 \uC5C6\uB294 \uACF5\uC9C0\uC0AC\uD56D',
+        preview: plainTextPreview || FALLBACK_PREVIEW,
+        views: notice.viewCount ?? 0,
+        dateLabel: formatNoticeDate(notice.noticeCreateDate),
+      };
+    });
   }, [noticeQuery.data?.data?.notices, notices]);
 
   const normalizedKeyword = searchKeyword.trim().toLowerCase();

--- a/src/shared/utils/html.ts
+++ b/src/shared/utils/html.ts
@@ -1,0 +1,35 @@
+const HTML_ENTITY_MAP: Record<string, string> = {
+  nbsp: ' ',
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+};
+
+const decodeHtmlEntities = (value: string) =>
+  value.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (entity, rawCode) => {
+    const code = rawCode.toLowerCase();
+
+    if (code in HTML_ENTITY_MAP) {
+      return HTML_ENTITY_MAP[code];
+    }
+
+    if (code.startsWith('#x')) {
+      const parsed = Number.parseInt(code.slice(2), 16);
+      return Number.isNaN(parsed) ? entity : String.fromCodePoint(parsed);
+    }
+
+    if (code.startsWith('#')) {
+      const parsed = Number.parseInt(code.slice(1), 10);
+      return Number.isNaN(parsed) ? entity : String.fromCodePoint(parsed);
+    }
+
+    return entity;
+  });
+
+export const stripHtmlToText = (value?: string) =>
+  decodeHtmlEntities(value ?? '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #47

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 설명
  공지사항 리스트 카드에서 파일명 대신 공지 `context`의 본문 텍스트를 미리보기로 노출하도록 수정했습니다.                             
  미리보기는 HTML 태그와 엔티티를 제거한 순수 텍스트만 사용하며, 카드 UI에서는 기존처럼 3줄까지만 표시되고 말줄임 처리됩니다.  
## 🚀 해결한 TODO

  - [x] 공지사항 리스트 카드 미리보기 데이터 소스 변경                                                                                
  - [x] HTML 제거용 공통 유틸 추가                      

## ✅ 상세 설명💎
  - `use-notice-section`에서 `noticeFileName` 대신 `context`를 기반으로 `preview`를 생성하도록 변경했습니다.                          
  - `stripHtmlToText` 유틸을 추가해 HTML 태그, 공백성 엔티티, 기본 HTML 엔티티를 제거/정리하도록 했습니다.                            
  - 본문 텍스트가 없는 경우에는 기존 fallback 문구를 유지합니다.      



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Notice previews now generate from article content instead of metadata, with HTML automatically stripped to plain text.
  * Updated default preview text when content is unavailable.
  * Removed summary section from notice detail pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->