### PR TITLE
[Fix/#43] 유저 수정 시 Member 필드 축소 (Admin)

### DIFF
--- a/src/shared/components/admin/user-list/use-user-create-drawer.ts
+++ b/src/shared/components/admin/user-list/use-user-create-drawer.ts
@@ -12,10 +12,10 @@ import { useQueryClient } from '@tanstack/react-query';
 import { formatPhoneNumber } from '@utils/format';
 import { useEffect, useMemo, useState, type ChangeEvent } from 'react';
 import {
+  getStepFieldsByRole,
   INITIAL_FORM,
   POSTCODE_SCRIPT_ID,
   POSTCODE_SCRIPT_SRC,
-  STEP_FIELDS,
 } from './user-drawer.constants';
 import { buildRoadAddress, getDrawerErrorMessage } from './user-drawer.utils';
 import type {
@@ -57,14 +57,15 @@ export const useUserCreateDrawer = ({
   const [editingUserId, setEditingUserId] = useState<number | null>(null);
   const [isPostcodeReady, setIsPostcodeReady] = useState(false);
   const [form, setForm] = useState<CreateCompanyForm>(INITIAL_FORM);
+  const stepFields = useMemo(() => getStepFieldsByRole(selectedRole), [selectedRole]);
 
   const isEditMode = mode === 'edit';
   const isSubmitting = createCompanyMutation.isPending || updateUserMutation.isPending;
   const activeStep = useMemo(
-    () => STEP_FIELDS.find((item) => item.step === currentStep) ?? STEP_FIELDS[0],
-    [currentStep],
+    () => stepFields.find((item) => item.step === currentStep) ?? stepFields[0],
+    [currentStep, stepFields],
   );
-  const isLastStep = currentStep === STEP_FIELDS.length;
+  const isLastStep = currentStep === stepFields.length;
 
   const resetDrawer = () => {
     setCurrentStep(1);
@@ -103,7 +104,7 @@ export const useUserCreateDrawer = ({
   };
 
   const validateStep = (step: number) => {
-    const stepConfig = STEP_FIELDS.find((item) => item.step === step);
+    const stepConfig = stepFields.find((item) => item.step === step);
 
     if (!stepConfig) {
       return true;
@@ -130,11 +131,13 @@ export const useUserCreateDrawer = ({
       return;
     }
 
-    setCurrentStep((step) => Math.min(STEP_FIELDS.length, step + 1));
+    setCurrentStep((step) => Math.min(stepFields.length, step + 1));
   };
 
   const handleSubmit = async () => {
-    if (!validateStep(1) || !validateStep(2) || !validateStep(3)) {
+    const hasInvalidStep = stepFields.some((step) => !validateStep(step.step));
+
+    if (hasInvalidStep) {
       return;
     }
 
@@ -157,15 +160,19 @@ export const useUserCreateDrawer = ({
             addressDetail: form.addressDetail.trim(),
             zipCode: form.zipCode.trim(),
           },
-          company: {
-            companyName: form.companyName.trim(),
-            managerName: form.managerName.trim(),
-            managerPhone: form.managerPhone.trim(),
-            companyNumber: form.companyNumber.trim(),
-            companyType: form.companyType.trim(),
-            companyItem: form.companyItem.trim(),
-            companyDescription: form.companyDescription.trim(),
-          },
+          ...(selectedRole === SignUpUserInfoDtoRole.MEMBER
+            ? {}
+            : {
+                company: {
+                  companyName: form.companyName.trim(),
+                  managerName: form.managerName.trim(),
+                  managerPhone: form.managerPhone.trim(),
+                  companyNumber: form.companyNumber.trim(),
+                  companyType: form.companyType.trim(),
+                  companyItem: form.companyItem.trim(),
+                  companyDescription: form.companyDescription.trim(),
+                },
+              }),
         };
 
         await updateUserMutation.mutateAsync({ userId: editingUserId, data: payload });
@@ -183,15 +190,19 @@ export const useUserCreateDrawer = ({
             addressDetail: form.addressDetail.trim(),
             zipCode: form.zipCode.trim(),
           },
-          company: {
-            managerName: form.managerName.trim(),
-            managerPhone: form.managerPhone.trim(),
-            companyName: form.companyName.trim(),
-            companyNumber: form.companyNumber.trim(),
-            companyType: form.companyType.trim(),
-            companyItem: form.companyItem.trim(),
-            companyDescription: form.companyDescription.trim(),
-          },
+          ...(selectedRole === SignUpUserInfoDtoRole.MEMBER
+            ? {}
+            : {
+                company: {
+                  managerName: form.managerName.trim(),
+                  managerPhone: form.managerPhone.trim(),
+                  companyName: form.companyName.trim(),
+                  companyNumber: form.companyNumber.trim(),
+                  companyType: form.companyType.trim(),
+                  companyItem: form.companyItem.trim(),
+                  companyDescription: form.companyDescription.trim(),
+                },
+              }),
         };
 
         await createCompanyMutation.mutateAsync({ data: payload });
@@ -205,6 +216,10 @@ export const useUserCreateDrawer = ({
       toastError(getDrawerErrorMessage(error, mode));
     }
   };
+
+  useEffect(() => {
+    setCurrentStep((step) => Math.min(step, stepFields.length));
+  }, [stepFields.length]);
 
   useEffect(() => {
     if (window.daum?.Postcode) {
@@ -281,6 +296,7 @@ export const useUserCreateDrawer = ({
     isPostcodeReady,
     isSubmitting,
     selectedRole,
+    stepFields,
     setCurrentStep,
     setSelectedRole,
     handleAddressSearch,

--- a/src/shared/components/admin/user-list/user-create-drawer.tsx
+++ b/src/shared/components/admin/user-list/user-create-drawer.tsx
@@ -5,7 +5,6 @@ import {
   inputClass,
   labelClass,
   ROLE_OPTIONS,
-  STEP_FIELDS,
 } from './user-drawer.constants';
 import { useUserCreateDrawer } from './use-user-create-drawer';
 import type { UserDrawerInitialData } from './user-drawer.types';
@@ -40,6 +39,7 @@ const UserCreateDrawer = ({
     selectedRole,
     setCurrentStep,
     setSelectedRole,
+    stepFields,
   } = useUserCreateDrawer({
     open,
     mode,
@@ -101,7 +101,7 @@ const UserCreateDrawer = ({
 
             <div className="flex flex-col gap-[4rem] pt-[2rem]">
               <div className="flex gap-2">
-                {STEP_FIELDS.map((item) => (
+                {stepFields.map((item) => (
                   <div
                     key={item.step}
                     className={[

--- a/src/shared/components/admin/user-list/user-drawer.constants.ts
+++ b/src/shared/components/admin/user-list/user-drawer.constants.ts
@@ -99,6 +99,31 @@ export const STEP_FIELDS: Array<{
   },
 ];
 
+const PICKED_MEMBER_FIELD_KEYS: Array<Array<keyof CreateCompanyForm>> = [
+  ['username', 'userid', 'password'],
+  ['phone', 'email'],
+  ['zipCode', 'address', 'addressDetail'],
+];
+
+export const getStepFieldsByRole = (role: DrawerRole) => {
+  if (role !== SignUpUserInfoDtoRole.MEMBER) {
+    return STEP_FIELDS;
+  }
+
+  return STEP_FIELDS.slice(0, 3).map((step, index) => {
+    const pickedKeys = PICKED_MEMBER_FIELD_KEYS[index] ?? [];
+    const pickedFields = pickedKeys
+      .map((key) => step.fields.find((field) => field.key === key))
+      .filter((field): field is StepField => field !== undefined);
+
+    return {
+      ...step,
+      title: index === 2 ? '주소 정보' : step.title,
+      fields: pickedFields,
+    };
+  });
+};
+
 export const labelClass =
   "font-['Pretendard',sans-serif] text-[1.25rem] font-semibold text-[#2B2B2B]";
 


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #43

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

  ## 🔎 설명                                                                                                                          
                                                                                                                                      
  어드민 유저 수정/등록 드로어에서 회원 유형이 Member인 경우, 불필요한 업체 정보 필드를 노출하지 않도록 역할별 폼 구성을 분리했습니다.  이제 Member는 회원명, 아이디, 비밀번호, 전화번호, 이메일, 주소(우편번호, 주소, 상세주소)만 표시되고 수정됩니다.                     
                                                                                                                                      
  ## 🚀 해결한 TODO                                                                                                                   
                                                                                                                                      
  - [x] Member 역할일 때 노출할 필드만 별도로 구성                                                                                    
  - [x] Member 역할일 때 회사 정보 단계가 보이지 않도록 수정                                                                          
  - [x] Member 저장 시 회사 정보가 payload에 포함되지 않도록 분기 처리                                                                
                                                                                                                                      
  ## 상세 설명💎                                                                                                                      
                                                                                                                                      
  어드민 유저 드로어의 기존 단계형 폼은 역할과 관계없이 동일한 필드를 모두 노출하고 있었습니다.                                       
  이번 변경에서는 역할별 step 구성을 적용해 Member는 기본 회원 정보와 주소 정보만 다루도록 수정했습니다.                              

  추가로 저장 로직에서도 Member의 경우 company 데이터를 제외하도록 처리해, 화면 노출과 실제 수정 대상이 일치하도록 맞췄습니다. 관련 변경은 어드민 유저 드로어의 상수 정의, step 계산 로직, 제출 payload 분기 처리에 반영했습니다.                                  
                                                                                                                                      
  ## 💎 새롭게 알게 된 / 공부한 내용                                                                                                  
                                                                                                                                      
  역할 기반 UI 분기는 화면에서 숨기는 것만으로 끝나면 안 되고, 제출 payload까지 동일한 기준으로 제한해야 실제 요구사항과 데이터 정합성 이 맞는다는 점을 다시 확인했습니다.    