### PR TITLE
[Style/#41] 관리자 대시보드 차트 수정

### DIFF
--- a/src/shared/hooks/use-access-status-chart.ts
+++ b/src/shared/hooks/use-access-status-chart.ts
@@ -119,8 +119,7 @@ function parseDailyPoint(hit: HitDTO, selectedYear: number, selectedMonth: numbe
 
   return {
     id: `daily-${rawName || safeDay || 'unknown'}`,
-    label: safeDay ? String(safeDay) : rawName || '-',
-    subLabel: MONTH_LABELS[selectedMonth - 1],
+    label: safeDay ? `${safeDay}\uC77C` : rawName || '-',
     tooltipLabel: safeDay
       ? `${selectedYear}.${String(selectedMonth).padStart(2, '0')}.${String(safeDay).padStart(2, '0')}`
       : rawName || '-',

--- a/src/shared/hooks/use-access-status-chart.ts
+++ b/src/shared/hooks/use-access-status-chart.ts
@@ -71,6 +71,7 @@ const HIT_FILTER_MAP: Record<ChartFilter, string> = {
 };
 
 export const MONTHS = MONTH_LABELS;
+const HITS_QUERY_STALE_TIME = 60_000;
 
 function clampPage(page: number, maxPage: number) {
   return Math.min(Math.max(page, 0), maxPage);
@@ -227,11 +228,44 @@ export function useAccessStatusChart() {
     company: 0,
   });
 
-  const hitsQuery = useGetHits(getHitsParams(filter, selectedYear, selectedMonth), {
+  const dailyHitsQuery = useGetHits(
+    getHitsParams('daily', selectedYear, selectedMonth),
+    {
+      query: {
+        staleTime: HITS_QUERY_STALE_TIME,
+      },
+    },
+  );
+  const monthlyHitsQuery = useGetHits(getHitsParams('monthly', selectedYear, selectedMonth), {
     query: {
-      staleTime: 60_000,
+      staleTime: HITS_QUERY_STALE_TIME,
     },
   });
+  const weekdayHitsQuery = useGetHits(
+    getHitsParams('weekday', selectedYear, selectedMonth),
+    {
+      query: {
+        staleTime: HITS_QUERY_STALE_TIME,
+      },
+    },
+  );
+  const companyHitsQuery = useGetHits(
+    getHitsParams('company', selectedYear, selectedMonth),
+    {
+      query: {
+        staleTime: HITS_QUERY_STALE_TIME,
+      },
+    },
+  );
+
+  const hitsQueryByFilter = {
+    daily: dailyHitsQuery,
+    monthly: monthlyHitsQuery,
+    weekday: weekdayHitsQuery,
+    company: companyHitsQuery,
+  } satisfies Record<ChartFilter, typeof dailyHitsQuery>;
+
+  const activeHitsQuery = hitsQueryByFilter[filter];
 
   useEffect(() => {
     const raf = window.requestAnimationFrame(() => setIsReady(true));
@@ -259,11 +293,11 @@ export function useAccessStatusChart() {
     () =>
       mapHitsToData(
         filter,
-        hitsQuery.data?.data?.hits ?? [],
+        activeHitsQuery.data?.data?.hits ?? [],
         selectedYear,
         selectedMonth,
       ),
-    [filter, hitsQuery.data?.data?.hits, selectedMonth, selectedYear],
+    [activeHitsQuery.data?.data?.hits, filter, selectedMonth, selectedYear],
   );
 
   const dataset = useMemo(
@@ -271,16 +305,16 @@ export function useAccessStatusChart() {
       buildDataset(
         chartData,
         pageByFilter[filter],
-        hitsQuery.data?.data?.totalHit ??
-          hitsQuery.data?.data?.overAllTotalHit ??
-          hitsQuery.data?.data?.averageHit,
+        activeHitsQuery.data?.data?.totalHit ??
+          activeHitsQuery.data?.data?.overAllTotalHit ??
+          activeHitsQuery.data?.data?.averageHit,
       ),
     [
+      activeHitsQuery.data?.data?.averageHit,
+      activeHitsQuery.data?.data?.overAllTotalHit,
+      activeHitsQuery.data?.data?.totalHit,
       chartData,
       filter,
-      hitsQuery.data?.data?.averageHit,
-      hitsQuery.data?.data?.overAllTotalHit,
-      hitsQuery.data?.data?.totalHit,
       pageByFilter,
     ],
   );
@@ -319,8 +353,8 @@ export function useAccessStatusChart() {
     activeFilterLabel,
     activeMonthLabel: `${selectedMonth}\uC6D4`,
     activeYearLabel: `${selectedYear}\uB144`,
-    isLoading: hitsQuery.isLoading,
-    isError: hitsQuery.isError,
+    isLoading: activeHitsQuery.isLoading,
+    isError: activeHitsQuery.isError,
     goToPrevPage: () => movePage('prev'),
     goToNextPage: () => movePage('next'),
   };

--- a/src/shared/hooks/use-access-status-chart.ts
+++ b/src/shared/hooks/use-access-status-chart.ts
@@ -72,6 +72,7 @@ const HIT_FILTER_MAP: Record<ChartFilter, string> = {
 
 export const MONTHS = MONTH_LABELS;
 const HITS_QUERY_STALE_TIME = 60_000;
+const COMPANY_LABEL_MAX_LENGTH = 8;
 
 function clampPage(page: number, maxPage: number) {
   return Math.min(Math.max(page, 0), maxPage);
@@ -79,6 +80,11 @@ function clampPage(page: number, maxPage: number) {
 
 function sumValues(data: DataPoint[]) {
   return data.reduce((total, item) => total + item.value, 0);
+}
+
+function truncateLabel(value: string, maxLength: number) {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}...`;
 }
 
 function getHitsParams(
@@ -163,7 +169,7 @@ function parseCompanyPoint(hit: HitDTO, index: number) {
 
   return {
     id: `company-${index}-${name}`,
-    label: name,
+    label: truncateLabel(name, COMPANY_LABEL_MAX_LENGTH),
     tooltipLabel: name,
     value: hit.hit ?? 0,
     sort: index,


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #41

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

  ## 🔎 설명
                                                                                                                                      
  어드민 대시보드 접속 현황 차트의 `hits` 표시 방식을 정리했어요.                                                               
  주요 변경점은 일별 라벨 표기 개선, 필터 전환 시 즉시 반영되도록 데이터 조회 구조 변경, 업체별 라벨 말줄임 처리입니다!                                                                                                                             
                                                                                                                                      
  ## 🚀 해결한 TODO                                                                                                                   

  - [x] 일별 그래프 라벨을 `1일`, `2일` 형태로 정리                                                                                   
  - [x] 월별/일별/업체별 등 필터 데이터를 병렬로 미리 조회하도록 개선                                                                 
  - [x] 업체별 라벨이 길 경우 차트 축에서 말줄임 처리                                                                                 
                                                                                                                                      
  ## 상세 설명💎                                                                                                                      
                                                                                                                                      
  - `src/shared/hooks/use-access-status-chart.ts`                                                                                     
    - 일별 데이터 파싱 시 월 `subLabel`을 제거하고 `n일` 형식으로 라벨을 통일했습니다.                                                
    - 기존에는 현재 선택한 필터에 대해서만 `useGetHits`를 호출했는데, 이제 `daily`, `monthly`, `weekday`, `company`를 각각 병렬로 조회
  한 뒤 현재 필터에 맞는 캐시 데이터를 사용하도록 변경했습니다.                                                                       
    - 업체별 라벨은 최대 8자 뒤에 `...`를 붙이도록 처리하고, `tooltipLabel`에는 전체 업체명을 유지하도록 분리했습니다.                
    - `staleTime` 상수를 분리해 쿼리 설정을 정리했습니다.                                                                             
                                                                                                                                      
  ## 💎 새롭게 알게 된 / 공부한 내용                                                                                                  
                                                                                                                                      
  - React Query에서 필터 전환 UX를 개선할 때는 현재 필터 하나만 다시 부르는 방식보다, 조건별 쿼리를 미리 병렬로 구성하고 active query만 바인딩하는 방식이 더 자연스럽다,,                                                                                       
  - 차트 축 라벨은 전체 문자열을 그대로 노출하기보다, `label`과 `tooltipLabel`을 분리해서 축은 짧게, 상세는 전체로 보여주는 식이 유지보수에 유리하다는 생각이 들었어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart labels now display with day suffixes.
  * Company names in charts are truncated for readability, with full names visible in tooltips.

* **Refactor**
  * Optimized data fetching mechanism for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->