### PR TITLE
[Feat/#52] 커서 기반 페이징 구현 (All)

### DIFF
--- a/src/pages/admin/notices/notices.tsx
+++ b/src/pages/admin/notices/notices.tsx
@@ -4,6 +4,7 @@ import LoadingPanel from '@components/common/loading-panel';
 import SearchBar from '@components/common/search-bar';
 import NoticeCard from '@components/notice/notice-card';
 import { useNoticeSection } from '@hooks/use-notice-section';
+import { useInfiniteScrollTrigger } from '@hooks/use-infinite-scroll-trigger';
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FiPlus } from 'react-icons/fi';
@@ -14,9 +15,15 @@ const AdminNotices = () => {
   const [keyword, setKeyword] = useState('');
   const [searchKeyword, setSearchKeyword] = useState('');
 
-  const { notices, isLoading, isError } = useNoticeSection({
-    pageSize: 100,
+  const { notices, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useNoticeSection({
+    pageSize: 10,
     searchKeyword,
+  });
+
+  const loadMoreRef = useInfiniteScrollTrigger({
+    enabled: hasNextPage && !isFetchingNextPage,
+    onLoadMore: () => fetchNextPage(),
   });
 
   const handleSearch = (value: string) => {
@@ -79,6 +86,15 @@ const AdminNotices = () => {
               }}
             />
           ))}
+          {(hasNextPage || isFetchingNextPage) ? (
+            <div ref={loadMoreRef}>
+              {isFetchingNextPage ? (
+                <LoadingPanel className="min-h-0 rounded-2xl py-[2rem]" size={72} />
+              ) : (
+                <div className="h-[1px] w-full" />
+              )}
+            </div>
+          ) : null}
         </div>
       ) : (
         <div className="rounded-2xl bg-white px-[2.2rem] py-[2rem] text-[1.6rem] text-gray-500">

--- a/src/pages/admin/orders/orders.tsx
+++ b/src/pages/admin/orders/orders.tsx
@@ -3,6 +3,7 @@ import ExploreScrollToTop from '@components/common/explore-scroll-to-top';
 import LoadingPanel from '@components/common/loading-panel';
 import SearchBar from '@components/common/search-bar';
 import OrderListTable from '@components/order/order-list-table';
+import { useInfiniteScrollTrigger } from '@hooks/use-infinite-scroll-trigger';
 import useOrderList, { type OrderFilterType } from '@hooks/use-order-list';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -22,10 +23,22 @@ const AdminOrders = () => {
   const [appliedFilterBy, setAppliedFilterBy] = useState<OrderFilterType>();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const filterRef = useRef<HTMLDivElement>(null);
-  const { orders, isLoading, isError } = useOrderList({
-    pageSize: 10000,
+  const {
+    orders,
+    isLoading,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useOrderList({
+    pageSize: 10,
     searchKeyword: appliedSearchKeyword,
     filterBy: appliedFilterBy,
+  });
+
+  const loadMoreRef = useInfiniteScrollTrigger({
+    enabled: hasNextPage && !isFetchingNextPage,
+    onLoadMore: () => fetchNextPage(),
   });
 
   const selectedFilterLabel =
@@ -119,7 +132,18 @@ const AdminOrders = () => {
           주문 목록을 불러오지 못했습니다.
         </div>
       ) : orders.length ? (
-        <OrderListTable data={orders} detailBasePath="/admin/orders" />
+        <div className="flex flex-col gap-4">
+          <OrderListTable data={orders} detailBasePath="/admin/orders" />
+          {(hasNextPage || isFetchingNextPage) ? (
+            <div ref={loadMoreRef}>
+              {isFetchingNextPage ? (
+                <LoadingPanel className="min-h-0 rounded-[1.6rem] py-[2rem]" size={72} />
+              ) : (
+                <div className="h-[1px] w-full" />
+              )}
+            </div>
+          ) : null}
+        </div>
       ) : (
         <div className="rounded-[1.6rem] bg-white px-[2.2rem] py-[2rem] text-[1.6rem] text-gray-500">
           표시할 주문 내역이 없습니다.

--- a/src/pages/app/cart/use-cart-items-query.ts
+++ b/src/pages/app/cart/use-cart-items-query.ts
@@ -1,13 +1,23 @@
 import { useEffect, useMemo } from 'react';
 
 import { useInfiniteCartItems } from '@apis/telegro';
-import type { CartResponseDTO, SuccessResponseCartListDTO } from '@apis/telegro';
+import type {
+  CartResponseDTO,
+  SuccessResponseCartListDTO,
+} from '@apis/telegro';
 
 import { mapCartResponseToCartItems } from './cart.adapters';
 
 export const CART_ITEMS_QUERY_PARAMS = {
-  size: 10,
+  size: 20,
 };
+
+type CartPagePayload =
+  | CartResponseDTO[]
+  | {
+      content?: CartResponseDTO[];
+    }
+  | undefined;
 
 export const useCartItemsQuery = () => {
   const query = useInfiniteCartItems(CART_ITEMS_QUERY_PARAMS, {
@@ -25,7 +35,7 @@ export const useCartItemsQuery = () => {
       mapCartResponseToCartItems(
         (query.data?.pages ?? []).reduce<CartResponseDTO[]>(
           (acc, page: SuccessResponseCartListDTO) => {
-            const carts = page.data?.carts;
+            const carts = page.data?.carts as CartPagePayload;
             const normalizedCarts = Array.isArray(carts)
               ? carts
               : Array.isArray(carts?.content)

--- a/src/pages/app/cart/use-cart-items-query.ts
+++ b/src/pages/app/cart/use-cart-items-query.ts
@@ -1,24 +1,42 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
-import { useGetCartItems } from '@apis/telegro';
+import { useInfiniteCartItems } from '@apis/telegro';
+import type { CartResponseDTO, SuccessResponseCartListDTO } from '@apis/telegro';
 
 import { mapCartResponseToCartItems } from './cart.adapters';
 
 export const CART_ITEMS_QUERY_PARAMS = {
-  page: 0,
-  size: 100,
+  size: 10,
 };
 
 export const useCartItemsQuery = () => {
-  const query = useGetCartItems(CART_ITEMS_QUERY_PARAMS, {
-    query: {
-      staleTime: 60_000,
-    },
+  const query = useInfiniteCartItems(CART_ITEMS_QUERY_PARAMS, {
+    staleTime: 60_000,
   });
 
+  useEffect(() => {
+    if (query.hasNextPage && !query.isFetchingNextPage) {
+      void query.fetchNextPage();
+    }
+  }, [query.hasNextPage, query.isFetchingNextPage, query.fetchNextPage]);
+
   const items = useMemo(
-    () => mapCartResponseToCartItems(query.data?.data?.carts),
-    [query.data?.data?.carts],
+    () =>
+      mapCartResponseToCartItems(
+        (query.data?.pages ?? []).reduce<CartResponseDTO[]>(
+          (acc, page: SuccessResponseCartListDTO) => {
+            const carts = page.data?.carts;
+            const normalizedCarts = Array.isArray(carts)
+              ? carts
+              : Array.isArray(carts?.content)
+                ? carts.content
+                : [];
+            return [...acc, ...normalizedCarts];
+          },
+          [],
+        ),
+      ),
+    [query.data?.pages],
   );
 
   return {

--- a/src/pages/app/my/use-my-page.ts
+++ b/src/pages/app/my/use-my-page.ts
@@ -26,7 +26,7 @@ export function useMyPage() {
   const [addressForm, setAddressForm] = useState<AddressForm>(INITIAL_ADDRESS_FORM);
 
   const myPageQuery = useGetMyPage({ query: { staleTime: 60_000 } });
-  const ordersQuery = useGetOrders({ page: 0, size: 4 }, { query: { staleTime: 60_000 } });
+  const ordersQuery = useGetOrders({ size: 4 }, { query: { staleTime: 60_000 } });
   const addAddressMutation = useAddDeliveryAddress();
   const updateAddressMutation = useUpdateDeliveryAddress();
   const deleteAddressMutation = useDeleteDeliveryAddress();

--- a/src/pages/app/orders/orders.tsx
+++ b/src/pages/app/orders/orders.tsx
@@ -2,6 +2,7 @@ import ExploreScrollToTop from '@components/common/explore-scroll-to-top';
 import LoadingPanel from '@components/common/loading-panel';
 import SearchBar from '@components/common/search-bar';
 import OrderListTable from '@components/order/order-list-table';
+import { useInfiniteScrollTrigger } from '@hooks/use-infinite-scroll-trigger';
 import useOrderList, { type OrderFilterType } from '@hooks/use-order-list';
 import { useEffect, useRef, useState } from 'react';
 
@@ -19,10 +20,22 @@ const Orders = () => {
   const [appliedFilterBy, setAppliedFilterBy] = useState<OrderFilterType>();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const filterRef = useRef<HTMLDivElement>(null);
-  const { orders, isLoading, isError } = useOrderList({
-    pageSize: 10000,
+  const {
+    orders,
+    isLoading,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useOrderList({
+    pageSize: 10,
     searchKeyword: appliedSearchKeyword,
     filterBy: appliedFilterBy,
+  });
+
+  const loadMoreRef = useInfiniteScrollTrigger({
+    enabled: hasNextPage && !isFetchingNextPage,
+    onLoadMore: () => fetchNextPage(),
   });
 
   const selectedFilterLabel =
@@ -114,7 +127,18 @@ const Orders = () => {
           주문 목록을 불러오지 못했습니다.
         </div>
       ) : orders.length ? (
-        <OrderListTable data={orders} />
+        <div className="flex flex-col gap-4">
+          <OrderListTable data={orders} />
+          {(hasNextPage || isFetchingNextPage) ? (
+            <div ref={loadMoreRef}>
+              {isFetchingNextPage ? (
+                <LoadingPanel className="min-h-0 rounded-[1.6rem] py-[2rem]" size={72} />
+              ) : (
+                <div className="h-[1px] w-full" />
+              )}
+            </div>
+          ) : null}
+        </div>
       ) : (
         <div className="rounded-[1.6rem] bg-white px-[2.2rem] py-[2rem] text-[1.6rem] text-gray-500">
           표시할 주문 내역이 없습니다.

--- a/src/pages/public/notices/notices.tsx
+++ b/src/pages/public/notices/notices.tsx
@@ -3,6 +3,7 @@ import LoadingPanel from '@components/common/loading-panel';
 import SearchBar from '@components/common/search-bar';
 import NoticeCard from '@components/notice/notice-card';
 import { useNoticeSection } from '@hooks/use-notice-section';
+import { useInfiniteScrollTrigger } from '@hooks/use-infinite-scroll-trigger';
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -12,9 +13,15 @@ const Notices = () => {
   const [keyword, setKeyword] = useState('');
   const [searchKeyword, setSearchKeyword] = useState('');
 
-  const { notices, isLoading, isError } = useNoticeSection({
-    pageSize: 100,
+  const { notices, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useNoticeSection({
+    pageSize: 10,
     searchKeyword,
+  });
+
+  const loadMoreRef = useInfiniteScrollTrigger({
+    enabled: hasNextPage && !isFetchingNextPage,
+    onLoadMore: () => fetchNextPage(),
   });
 
   const handleSearch = (value: string) => {
@@ -61,6 +68,15 @@ const Notices = () => {
               }}
             />
           ))}
+          {(hasNextPage || isFetchingNextPage) ? (
+            <div ref={loadMoreRef}>
+              {isFetchingNextPage ? (
+                <LoadingPanel className="min-h-0 rounded-2xl py-[2rem]" size={72} />
+              ) : (
+                <div className="h-[1px] w-full" />
+              )}
+            </div>
+          ) : null}
         </div>
       ) : (
         <div className="rounded-2xl bg-white px-[2.2rem] py-[2rem] text-[1.6rem] text-gray-500">

--- a/src/shared/apis/telegro/axios-instance.ts
+++ b/src/shared/apis/telegro/axios-instance.ts
@@ -5,11 +5,35 @@ export const AXIOS_INSTANCE = Axios.create({
   withCredentials: true,
 });
 
+let isHandlingUnauthorized = false;
+
 AXIOS_INSTANCE.interceptors.request.use((config) => {
   const token = localStorage.getItem('accessToken');
   if (token) config.headers.Authorization = `Bearer ${token}`;
   return config;
 });
+
+AXIOS_INSTANCE.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error?.response?.status;
+    const requestUrl = String(error?.config?.url ?? '');
+    const isAuthRequest =
+      requestUrl.includes('/auth/login') || requestUrl.includes('/auth/signup');
+
+    if (status === 401 && !isAuthRequest && typeof window !== 'undefined') {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('userRole');
+
+      if (!isHandlingUnauthorized) {
+        isHandlingUnauthorized = true;
+        window.location.replace('/');
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
 
 export const axiosInstance = async <T>(
   config: AxiosRequestConfig,

--- a/src/shared/apis/telegro/cursor.ts
+++ b/src/shared/apis/telegro/cursor.ts
@@ -21,6 +21,8 @@ import { axiosInstance, type ErrorType } from './axios-instance';
 
 type CursorValue = number | string | Record<string, unknown>;
 
+type CursorRecord = Record<string, unknown>;
+
 type CursorMeta = {
   cursor?: CursorValue | null;
   nextCursor?: CursorValue | null;
@@ -54,6 +56,26 @@ type NoticeCursorPayload = CursorMeta & {
   } | null;
 };
 
+type OrderCursorPayload = CursorMeta & {
+  content?: OrderDetailDTO[];
+  nextCursorId?: number | string | null;
+  nextCursorCreatedAt?: string | null;
+  orders?:
+    | OrderDetailDTO[]
+    | {
+        content?: OrderDetailDTO[];
+        hasNext?: boolean;
+        nextCursorId?: number | string | null;
+        nextCursorCreatedAt?: string | null;
+        nextCursor?: {
+          cursorId?: number | string | null;
+          cursorCreatedAt?: string | null;
+          lastId?: number | string | null;
+          lastCreatedAt?: string | null;
+        } | null;
+      };
+};
+
 type OrderCursorParams = Omit<GetOrdersParams, 'page'> & {
   size: number;
   cursor?: CursorValue;
@@ -74,7 +96,7 @@ type InfiniteHookOptions = {
   staleTime?: number;
 };
 
-const CURSOR_PARAM_KEY = 'cursor';
+const CURSOR_PARAM_KEY = 'cursorId';
 
 const serializeCursor = (cursor: CursorValue | undefined) => {
   if (cursor === undefined || cursor === null || cursor === '') {
@@ -88,24 +110,129 @@ const serializeCursor = (cursor: CursorValue | undefined) => {
   return String(cursor);
 };
 
-const isCursorRecord = (cursor: CursorValue | undefined): cursor is Record<string, unknown> =>
-  typeof cursor === 'object' && cursor !== null && !Array.isArray(cursor);
+const hasCursorValue = (value: unknown) => value !== undefined && value !== null && value !== '';
+
+const getContentArray = <TItem>(value: unknown): TItem[] => {
+  if (Array.isArray(value)) {
+    return value as TItem[];
+  }
+
+  if (value && typeof value === 'object' && Array.isArray((value as { content?: unknown[] }).content)) {
+    return (value as { content: TItem[] }).content;
+  }
+
+  return [];
+};
+
+const getLastArrayItem = <TItem>(items: TItem[]) => (items.length ? items[items.length - 1] : undefined);
+
+const getBoolean = (value: unknown) => (typeof value === 'boolean' ? value : undefined);
+
+const getNumberOrString = (value: unknown) =>
+  typeof value === 'number' || typeof value === 'string' ? value : undefined;
+
+const getString = (value: unknown) => (typeof value === 'string' ? value : undefined);
+
+const toCursorRecord = (value: unknown): CursorRecord | undefined =>
+  value && typeof value === 'object' && !Array.isArray(value) ? (value as CursorRecord) : undefined;
+
+const getOrderCursorPayload = (data: OrderCursorPayload | undefined) => {
+  const nestedOrders = toCursorRecord(data?.orders);
+
+  return {
+    items: getContentArray<OrderDetailDTO>(data?.content ?? data?.orders),
+    hasNext:
+      data?.hasNext ??
+      getBoolean(nestedOrders?.hasNext) ??
+      (data?.isLast === true ? false : undefined),
+    cursorId:
+      getNumberOrString(data?.nextCursorId) ??
+      getNumberOrString(nestedOrders?.nextCursorId) ??
+      getNumberOrString(toCursorRecord(nestedOrders?.nextCursor)?.cursorId) ??
+      getNumberOrString(toCursorRecord(nestedOrders?.nextCursor)?.lastId),
+    cursorCreatedAt:
+      getString(data?.nextCursorCreatedAt) ??
+      getString(nestedOrders?.nextCursorCreatedAt) ??
+      getString(toCursorRecord(nestedOrders?.nextCursor)?.cursorCreatedAt) ??
+      getString(toCursorRecord(nestedOrders?.nextCursor)?.lastCreatedAt),
+  };
+};
+
+const getExplicitNextCursor = (
+  data: CursorMeta | undefined,
+  pageParam: CursorValue | undefined,
+  allPageParams: unknown[],
+) => {
+  if (!data) {
+    return undefined;
+  }
+
+  const nestedNextCursor = toCursorRecord(data.nextCursor);
+  const cursorId =
+    getNumberOrString((data as CursorRecord).nextCursorId) ??
+    getNumberOrString((data as CursorRecord).cursorId) ??
+    getNumberOrString(nestedNextCursor?.cursorId) ??
+    getNumberOrString(nestedNextCursor?.lastId);
+  const cursorCreatedAt =
+    getString((data as CursorRecord).nextCursorCreatedAt) ??
+    getString((data as CursorRecord).cursorCreatedAt) ??
+    getString(nestedNextCursor?.cursorCreatedAt) ??
+    getString(nestedNextCursor?.lastCreatedAt);
+
+  const recordCursor =
+    hasCursorValue(cursorId) || hasCursorValue(cursorCreatedAt)
+      ? {
+          ...(hasCursorValue(cursorId) ? { cursorId } : {}),
+          ...(hasCursorValue(cursorCreatedAt) ? { cursorCreatedAt } : {}),
+        }
+      : undefined;
+
+  const explicitCursor =
+    recordCursor ??
+    data.nextCursor ??
+    data.cursor ??
+    data.nextId ??
+    data.lastCursor;
+
+  if (!hasCursorValue(explicitCursor)) {
+    return undefined;
+  }
+
+  const nextCursorKey = serializeCursor(explicitCursor as CursorValue);
+  const currentCursorKey = serializeCursor(pageParam);
+  const seenCursor = allPageParams.some(
+    (currentPageParam) => serializeCursor(currentPageParam as CursorValue | undefined) === nextCursorKey,
+  );
+
+  if (nextCursorKey === currentCursorKey || seenCursor) {
+    return undefined;
+  }
+
+  return explicitCursor as CursorValue;
+};
 
 const resolveNextCursor = <TItem>(
   data: CursorMeta | undefined,
   items: TItem[],
   pageSize: number,
   getItemCursor: (item: TItem) => CursorValue | null | undefined,
+  pageParam?: CursorValue | undefined,
+  allPageParams: unknown[] = [],
 ) => {
   if (!data) {
     return undefined;
   }
 
-  if (data.hasNext === false || data.hasMore === false || data.isLast === true) {
+  if (
+    data.hasNext === false ||
+    data.hasMore === false ||
+    data.isLast === true ||
+    getBoolean((data as CursorRecord).hasNext) === false
+  ) {
     return undefined;
   }
 
-  const explicitCursor = data.nextCursor ?? data.cursor ?? data.nextId ?? data.lastCursor;
+  const explicitCursor = getExplicitNextCursor(data, pageParam, allPageParams);
   if (explicitCursor !== undefined && explicitCursor !== null && explicitCursor !== '') {
     return explicitCursor;
   }
@@ -181,10 +308,17 @@ export const useInfiniteProducts = (
     enabled: options?.enabled,
     queryFn: ({ pageParam, signal }) =>
       getCursorProducts({ ...params, cursor: pageParam as CursorValue | undefined }, undefined, signal),
-    getNextPageParam: (lastPage) => {
-      const data = lastPage.data as (ProductListDTO & CursorMeta) | undefined;
-      const items = data?.products ?? [];
-      return resolveNextCursor<ProductResponseDTO>(data, items, params.size, (item) => item.id);
+    getNextPageParam: (lastPage, _allPages, lastPageParam, allPageParams) => {
+      const data = lastPage.data as (ProductListDTO & CursorMeta & { content?: ProductResponseDTO[] }) | undefined;
+      const items = getContentArray<ProductResponseDTO>(data?.content ?? data?.products);
+      return resolveNextCursor<ProductResponseDTO>(
+        data,
+        items,
+        params.size,
+        (item) => item.id,
+        lastPageParam as CursorValue | undefined,
+        allPageParams,
+      );
     },
   });
 
@@ -222,38 +356,15 @@ export const useInfiniteNotices = (
       getCursorNotices({ ...params, cursor: pageParam as CursorValue | undefined }, undefined, signal),
     getNextPageParam: (lastPage, _allPages, lastPageParam, allPageParams) => {
       const data = lastPage.data as (NoticeListDTO & CursorMeta & NoticeCursorPayload) | undefined;
-
-      if (!data?.hasNext) {
-        return undefined;
-      }
-
-      const nextCursor: CursorValue = {
-        cursorId:
-          data?.nextCursorId ??
-          data?.nextCursor?.lastId ??
-          null,
-        cursorCreatedAt:
-          data?.nextCursorCreatedAt ??
-          data?.nextCursor?.lastCreatedAt ??
-          null,
-      };
-
-      const nextCursorKey = serializeCursor(nextCursor);
-      const currentCursorKey = serializeCursor(lastPageParam as CursorValue | undefined);
-      const seenCursor = allPageParams.some(
-        (pageParam) => serializeCursor(pageParam as CursorValue | undefined) === nextCursorKey,
+      const items = getContentArray<NoticeDTO>(data?.content ?? data?.notices);
+      return resolveNextCursor<NoticeDTO>(
+        data,
+        items,
+        params.size,
+        (item) => item.id,
+        lastPageParam as CursorValue | undefined,
+        allPageParams,
       );
-
-      if (
-        !isCursorRecord(nextCursor) ||
-        (!nextCursor.cursorId && !nextCursor.cursorCreatedAt) ||
-        nextCursorKey === currentCursorKey ||
-        seenCursor
-      ) {
-        return undefined;
-      }
-
-      return nextCursor;
     },
   });
 
@@ -299,10 +410,52 @@ export const useInfiniteOrders = (
     enabled: options?.enabled,
     queryFn: ({ pageParam, signal }) =>
       getCursorOrders({ ...params, cursor: pageParam as CursorValue | undefined }, undefined, signal),
-    getNextPageParam: (lastPage) => {
-      const data = lastPage.data as (OrderListDTO & CursorMeta) | undefined;
-      const items = data?.orders ?? [];
-      return resolveNextCursor<OrderDetailDTO>(data, items, params.size, (item) => item.orderId);
+    getNextPageParam: (lastPage, _allPages, lastPageParam, allPageParams) => {
+      const data = lastPage.data as (OrderListDTO & OrderCursorPayload) | undefined;
+      const { items, hasNext, cursorId, cursorCreatedAt } = getOrderCursorPayload(data);
+
+      if (hasNext === false) {
+        return undefined;
+      }
+
+      if (hasCursorValue(cursorId) || hasCursorValue(cursorCreatedAt)) {
+        const nextCursor = {
+          ...(hasCursorValue(cursorId) ? { cursorId } : {}),
+          ...(hasCursorValue(cursorCreatedAt) ? { cursorCreatedAt } : {}),
+        };
+        const nextCursorKey = serializeCursor(nextCursor);
+        const currentCursorKey = serializeCursor(lastPageParam as CursorValue | undefined);
+        const seenCursor = allPageParams.some(
+          (pageParam) => serializeCursor(pageParam as CursorValue | undefined) === nextCursorKey,
+        );
+
+        if (nextCursorKey === currentCursorKey || seenCursor) {
+          return undefined;
+        }
+
+        return nextCursor;
+      }
+
+      const lastOrder = getLastArrayItem(items);
+      if (!lastOrder?.orderId || !lastOrder.createdAt) {
+        return undefined;
+      }
+
+      const nextCursor = {
+        cursorId: lastOrder.orderId,
+        cursorCreatedAt: lastOrder.createdAt,
+      };
+      const nextCursorKey = serializeCursor(nextCursor);
+      const currentCursorKey = serializeCursor(lastPageParam as CursorValue | undefined);
+      const seenCursor = allPageParams.some(
+        (pageParam) => serializeCursor(pageParam as CursorValue | undefined) === nextCursorKey,
+      );
+
+      if (nextCursorKey === currentCursorKey || seenCursor) {
+        return undefined;
+      }
+
+      return nextCursor;
     },
   });
 
@@ -338,12 +491,19 @@ export const useInfiniteCartItems = (
     enabled: options?.enabled,
     queryFn: ({ pageParam, signal }) =>
       getCursorCartItems({ ...params, cursor: pageParam as CursorValue | undefined }, undefined, signal),
-    getNextPageParam: (lastPage) => {
+    getNextPageParam: (lastPage, _allPages, lastPageParam, allPageParams) => {
       const data = lastPage.data as (CartListDTO & CursorMeta) | undefined;
       const cartPayload = data?.carts as CartCursorPayload | CartResponseDTO[] | undefined;
-      const items = Array.isArray(cartPayload) ? cartPayload : cartPayload?.content ?? [];
-      const cursorMeta = Array.isArray(cartPayload) ? data : cartPayload;
-      return resolveNextCursor<CartResponseDTO>(cursorMeta, items, params.size, (item) => item.id);
+      const items = getContentArray<CartResponseDTO>(cartPayload);
+      const cursorMeta = (Array.isArray(cartPayload) ? data : cartPayload) as CursorMeta | undefined;
+      return resolveNextCursor<CartResponseDTO>(
+        cursorMeta,
+        items,
+        params.size,
+        (item) => item.id,
+        lastPageParam as CursorValue | undefined,
+        allPageParams,
+      );
     },
   });
 

--- a/src/shared/apis/telegro/cursor.ts
+++ b/src/shared/apis/telegro/cursor.ts
@@ -46,6 +46,12 @@ type NoticeCursorParams = {
 
 type NoticeCursorPayload = CursorMeta & {
   content?: NoticeDTO[];
+  nextCursorId?: number | string | null;
+  nextCursorCreatedAt?: string | null;
+  nextCursor?: {
+    lastId?: number | string | null;
+    lastCreatedAt?: string | null;
+  } | null;
 };
 
 type OrderCursorParams = Omit<GetOrdersParams, 'page'> & {
@@ -69,6 +75,21 @@ type InfiniteHookOptions = {
 };
 
 const CURSOR_PARAM_KEY = 'cursor';
+
+const serializeCursor = (cursor: CursorValue | undefined) => {
+  if (cursor === undefined || cursor === null || cursor === '') {
+    return '';
+  }
+
+  if (typeof cursor === 'object') {
+    return JSON.stringify(cursor);
+  }
+
+  return String(cursor);
+};
+
+const isCursorRecord = (cursor: CursorValue | undefined): cursor is Record<string, unknown> =>
+  typeof cursor === 'object' && cursor !== null && !Array.isArray(cursor);
 
 const resolveNextCursor = <TItem>(
   data: CursorMeta | undefined,
@@ -199,10 +220,40 @@ export const useInfiniteNotices = (
     enabled: options?.enabled,
     queryFn: ({ pageParam, signal }) =>
       getCursorNotices({ ...params, cursor: pageParam as CursorValue | undefined }, undefined, signal),
-    getNextPageParam: (lastPage) => {
+    getNextPageParam: (lastPage, _allPages, lastPageParam, allPageParams) => {
       const data = lastPage.data as (NoticeListDTO & CursorMeta & NoticeCursorPayload) | undefined;
-      const items = data?.content ?? data?.notices ?? [];
-      return resolveNextCursor<NoticeDTO>(data, items, params.size, (item) => item.id);
+
+      if (!data?.hasNext) {
+        return undefined;
+      }
+
+      const nextCursor: CursorValue = {
+        cursorId:
+          data?.nextCursorId ??
+          data?.nextCursor?.lastId ??
+          null,
+        cursorCreatedAt:
+          data?.nextCursorCreatedAt ??
+          data?.nextCursor?.lastCreatedAt ??
+          null,
+      };
+
+      const nextCursorKey = serializeCursor(nextCursor);
+      const currentCursorKey = serializeCursor(lastPageParam as CursorValue | undefined);
+      const seenCursor = allPageParams.some(
+        (pageParam) => serializeCursor(pageParam as CursorValue | undefined) === nextCursorKey,
+      );
+
+      if (
+        !isCursorRecord(nextCursor) ||
+        (!nextCursor.cursorId && !nextCursor.cursorCreatedAt) ||
+        nextCursorKey === currentCursorKey ||
+        seenCursor
+      ) {
+        return undefined;
+      }
+
+      return nextCursor;
     },
   });
 

--- a/src/shared/apis/telegro/cursor.ts
+++ b/src/shared/apis/telegro/cursor.ts
@@ -1,0 +1,302 @@
+import { useInfiniteQuery, type InfiniteData } from '@tanstack/react-query';
+import type { AxiosRequestConfig } from 'axios';
+
+import type {
+  CartListDTO,
+  CartResponseDTO,
+  GetOrdersParams,
+  GetProductsCategory,
+  NoticeDTO,
+  NoticeListDTO,
+  OrderDetailDTO,
+  OrderListDTO,
+  ProductListDTO,
+  ProductResponseDTO,
+  SuccessResponseCartListDTO,
+  SuccessResponseNoticeListDTO,
+  SuccessResponseOrderListDTO,
+  SuccessResponseProductListDTO,
+} from './$schemas';
+import { axiosInstance, type ErrorType } from './axios-instance';
+
+type CursorValue = number | string | Record<string, unknown>;
+
+type CursorMeta = {
+  cursor?: CursorValue | null;
+  nextCursor?: CursorValue | null;
+  nextId?: CursorValue | null;
+  lastCursor?: CursorValue | null;
+  hasNext?: boolean;
+  hasMore?: boolean;
+  isLast?: boolean;
+  totalElement?: number;
+  totalElements?: number;
+};
+
+type ProductCursorParams = {
+  category: GetProductsCategory;
+  size: number;
+  cursor?: CursorValue;
+};
+
+type NoticeCursorParams = {
+  size: number;
+  cursor?: CursorValue;
+};
+
+type NoticeCursorPayload = CursorMeta & {
+  content?: NoticeDTO[];
+};
+
+type OrderCursorParams = Omit<GetOrdersParams, 'page'> & {
+  size: number;
+  cursor?: CursorValue;
+  orderStatus?: string;
+};
+
+type CartCursorParams = {
+  size: number;
+  cursor?: CursorValue;
+};
+
+type CartCursorPayload = CursorMeta & {
+  content?: CartResponseDTO[];
+};
+
+type InfiniteHookOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+};
+
+const CURSOR_PARAM_KEY = 'cursor';
+
+const resolveNextCursor = <TItem>(
+  data: CursorMeta | undefined,
+  items: TItem[],
+  pageSize: number,
+  getItemCursor: (item: TItem) => CursorValue | null | undefined,
+) => {
+  if (!data) {
+    return undefined;
+  }
+
+  if (data.hasNext === false || data.hasMore === false || data.isLast === true) {
+    return undefined;
+  }
+
+  const explicitCursor = data.nextCursor ?? data.cursor ?? data.nextId ?? data.lastCursor;
+  if (explicitCursor !== undefined && explicitCursor !== null && explicitCursor !== '') {
+    return explicitCursor;
+  }
+
+  if (items.length < pageSize) {
+    return undefined;
+  }
+
+  const lastItem = items[items.length - 1];
+  if (!lastItem) {
+    return undefined;
+  }
+
+  return getItemCursor(lastItem) ?? undefined;
+};
+
+const withCursor = <TParams extends Record<string, unknown>>(
+  params: TParams,
+  cursor: CursorValue | undefined,
+) => {
+  if (cursor === undefined || cursor === null || cursor === '') {
+    return params;
+  }
+
+  if (typeof cursor === 'object' && !Array.isArray(cursor)) {
+    return {
+      ...params,
+      ...cursor,
+    };
+  }
+
+  return {
+    ...params,
+    [CURSOR_PARAM_KEY]: cursor,
+  };
+};
+
+export const getCursorProducts = (
+  params: ProductCursorParams,
+  options?: AxiosRequestConfig,
+  signal?: AbortSignal,
+) =>
+  axiosInstance<SuccessResponseProductListDTO>(
+    {
+      url: '/products',
+      method: 'GET',
+      params: withCursor(
+        {
+          category: params.category,
+          size: params.size,
+        },
+        params.cursor,
+      ),
+      signal,
+    },
+    options,
+  );
+
+export const useInfiniteProducts = (
+  params: Omit<ProductCursorParams, 'cursor'>,
+  options?: InfiniteHookOptions,
+) =>
+  useInfiniteQuery<
+    SuccessResponseProductListDTO,
+    InfiniteProductsError,
+    InfiniteData<SuccessResponseProductListDTO>,
+    readonly unknown[],
+    CursorValue | undefined
+  >({
+    queryKey: ['/products', 'cursor', params] as const,
+    initialPageParam: undefined as CursorValue | undefined,
+    staleTime: options?.staleTime ?? 60_000,
+    enabled: options?.enabled,
+    queryFn: ({ pageParam, signal }) =>
+      getCursorProducts({ ...params, cursor: pageParam as CursorValue | undefined }, undefined, signal),
+    getNextPageParam: (lastPage) => {
+      const data = lastPage.data as (ProductListDTO & CursorMeta) | undefined;
+      const items = data?.products ?? [];
+      return resolveNextCursor<ProductResponseDTO>(data, items, params.size, (item) => item.id);
+    },
+  });
+
+export const getCursorNotices = (
+  params: NoticeCursorParams,
+  options?: AxiosRequestConfig,
+  signal?: AbortSignal,
+) =>
+  axiosInstance<SuccessResponseNoticeListDTO>(
+    {
+      url: '/notices',
+      method: 'GET',
+      params: withCursor({ size: params.size }, params.cursor),
+      signal,
+    },
+    options,
+  );
+
+export const useInfiniteNotices = (
+  params: Omit<NoticeCursorParams, 'cursor'>,
+  options?: InfiniteHookOptions,
+) =>
+  useInfiniteQuery<
+    SuccessResponseNoticeListDTO,
+    InfiniteNoticesError,
+    InfiniteData<SuccessResponseNoticeListDTO>,
+    readonly unknown[],
+    CursorValue | undefined
+  >({
+    queryKey: ['/notices', 'cursor', params] as const,
+    initialPageParam: undefined as CursorValue | undefined,
+    staleTime: options?.staleTime ?? 60_000,
+    enabled: options?.enabled,
+    queryFn: ({ pageParam, signal }) =>
+      getCursorNotices({ ...params, cursor: pageParam as CursorValue | undefined }, undefined, signal),
+    getNextPageParam: (lastPage) => {
+      const data = lastPage.data as (NoticeListDTO & CursorMeta & NoticeCursorPayload) | undefined;
+      const items = data?.content ?? data?.notices ?? [];
+      return resolveNextCursor<NoticeDTO>(data, items, params.size, (item) => item.id);
+    },
+  });
+
+export const getCursorOrders = (
+  params: OrderCursorParams,
+  options?: AxiosRequestConfig,
+  signal?: AbortSignal,
+) =>
+  axiosInstance<SuccessResponseOrderListDTO>(
+    {
+      url: '/api/orders',
+      method: 'GET',
+      params: withCursor(
+        {
+          filterBy: params.filterBy,
+          q: params.q,
+          startDate: params.startDate,
+          endDate: params.endDate,
+          orderStatus: params.orderStatus,
+          size: params.size,
+        },
+        params.cursor,
+      ),
+      signal,
+    },
+    options,
+  );
+
+export const useInfiniteOrders = (
+  params: Omit<OrderCursorParams, 'cursor'>,
+  options?: InfiniteHookOptions,
+) =>
+  useInfiniteQuery<
+    SuccessResponseOrderListDTO,
+    InfiniteOrdersError,
+    InfiniteData<SuccessResponseOrderListDTO>,
+    readonly unknown[],
+    CursorValue | undefined
+  >({
+    queryKey: ['/api/orders', 'cursor', params] as const,
+    initialPageParam: undefined as CursorValue | undefined,
+    staleTime: options?.staleTime ?? 60_000,
+    enabled: options?.enabled,
+    queryFn: ({ pageParam, signal }) =>
+      getCursorOrders({ ...params, cursor: pageParam as CursorValue | undefined }, undefined, signal),
+    getNextPageParam: (lastPage) => {
+      const data = lastPage.data as (OrderListDTO & CursorMeta) | undefined;
+      const items = data?.orders ?? [];
+      return resolveNextCursor<OrderDetailDTO>(data, items, params.size, (item) => item.orderId);
+    },
+  });
+
+export const getCursorCartItems = (
+  params: CartCursorParams,
+  options?: AxiosRequestConfig,
+  signal?: AbortSignal,
+) =>
+  axiosInstance<SuccessResponseCartListDTO>(
+    {
+      url: '/api/carts',
+      method: 'GET',
+      params: withCursor({ size: params.size }, params.cursor),
+      signal,
+    },
+    options,
+  );
+
+export const useInfiniteCartItems = (
+  params: Omit<CartCursorParams, 'cursor'>,
+  options?: InfiniteHookOptions,
+) =>
+  useInfiniteQuery<
+    SuccessResponseCartListDTO,
+    InfiniteCartItemsError,
+    InfiniteData<SuccessResponseCartListDTO>,
+    readonly unknown[],
+    CursorValue | undefined
+  >({
+    queryKey: ['/api/carts', 'cursor', params] as const,
+    initialPageParam: undefined as CursorValue | undefined,
+    staleTime: options?.staleTime ?? 60_000,
+    enabled: options?.enabled,
+    queryFn: ({ pageParam, signal }) =>
+      getCursorCartItems({ ...params, cursor: pageParam as CursorValue | undefined }, undefined, signal),
+    getNextPageParam: (lastPage) => {
+      const data = lastPage.data as (CartListDTO & CursorMeta) | undefined;
+      const cartPayload = data?.carts as CartCursorPayload | CartResponseDTO[] | undefined;
+      const items = Array.isArray(cartPayload) ? cartPayload : cartPayload?.content ?? [];
+      const cursorMeta = Array.isArray(cartPayload) ? data : cartPayload;
+      return resolveNextCursor<CartResponseDTO>(cursorMeta, items, params.size, (item) => item.id);
+    },
+  });
+
+export type InfiniteProductsError = ErrorType<unknown>;
+export type InfiniteNoticesError = ErrorType<unknown>;
+export type InfiniteOrdersError = ErrorType<unknown>;
+export type InfiniteCartItemsError = ErrorType<unknown>;

--- a/src/shared/apis/telegro/index.ts
+++ b/src/shared/apis/telegro/index.ts
@@ -2,5 +2,6 @@ export * from './$client';
 export * from './$schemas';
 export * from './axios-instance';
 export * from './cache';
+export * from './cursor';
 export * from './mutation-options';
 export * from './query-options';

--- a/src/shared/components/order/order-list-table.tsx
+++ b/src/shared/components/order/order-list-table.tsx
@@ -245,9 +245,9 @@ const OrderListTable = ({ data, detailBasePath = '/app/orders' }: Props) => {
         </thead>
 
         <tbody>
-          {filteredData.map((row) => (
+          {filteredData.map((row, index) => (
             <tr
-              key={row.id}
+              key={`${row.orderId}-${index}`}
               onClick={() => navigate(`${detailBasePath}/${row.orderId}`)}
               className="h-[8rem] cursor-pointer border-b border-slate-200 transition last:border-b-0 hover:bg-[#FAFAFA]"
             >

--- a/src/shared/components/product-section/product-section-container.tsx
+++ b/src/shared/components/product-section/product-section-container.tsx
@@ -5,6 +5,7 @@ import {
   type ProductItem,
   type ProductCategory,
 } from '@hooks/use-product-section';
+import { useInfiniteScrollTrigger } from '@hooks/use-infinite-scroll-trigger';
 import ProductSectionView from './product-section-view';
 
 type ProductSectionContainerProps = {
@@ -38,6 +39,9 @@ export default function ProductSectionContainer({
     isLoading,
     isError,
     isArrowDisabled,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
     setActiveCategory,
     handleClickAll,
     handleClickArrow,
@@ -48,8 +52,14 @@ export default function ProductSectionContainer({
     onClickAll,
     onClickArrow,
     onClickProduct,
-    pageSize: pageSize ?? (variant === 'list' ? 100 : 4),
+    pageSize: pageSize ?? (variant === 'list' ? 10 : 4),
     searchKeyword,
+    variant,
+  });
+
+  const loadMoreRef = useInfiniteScrollTrigger({
+    enabled: variant === 'list' && hasNextPage && !isFetchingNextPage,
+    onLoadMore: () => fetchNextPage(),
   });
 
   return (
@@ -63,6 +73,9 @@ export default function ProductSectionContainer({
       isLoading={isLoading}
       isError={isError}
       isArrowDisabled={isArrowDisabled}
+      hasNextPage={hasNextPage}
+      isFetchingNextPage={isFetchingNextPage}
+      loadMoreRef={loadMoreRef}
       variant={variant}
       onChangeCategory={setActiveCategory}
       onClickAll={handleClickAll}

--- a/src/shared/components/product-section/product-section-view.tsx
+++ b/src/shared/components/product-section/product-section-view.tsx
@@ -1,3 +1,4 @@
+import type { RefObject } from 'react';
 import LoadingPanel from '@components/common/loading-panel';
 import type { ProductCategory, ProductItem } from '@hooks/use-product-section';
 import { cn } from '@utils/cn';
@@ -13,6 +14,9 @@ type ProductSectionViewProps = {
   isLoading: boolean;
   isError: boolean;
   isArrowDisabled: boolean;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  loadMoreRef: RefObject<HTMLDivElement | null>;
   variant?: 'dashboard' | 'list';
   onChangeCategory: (category: ProductCategory) => void;
   onClickAll: () => void;
@@ -30,6 +34,9 @@ export default function ProductSectionView({
   isLoading,
   isError,
   isArrowDisabled,
+  hasNextPage,
+  isFetchingNextPage,
+  loadMoreRef,
   variant = 'dashboard',
   onChangeCategory,
   onClickAll,
@@ -146,6 +153,16 @@ export default function ProductSectionView({
           </button>
         ) : null}
       </div>
+
+      {!isDashboard && (hasNextPage || isFetchingNextPage) ? (
+        <div ref={loadMoreRef} className="w-full">
+          {isFetchingNextPage ? (
+            <LoadingPanel className="min-h-0 rounded-[1.6rem] bg-transparent py-[2rem]" size={72} />
+          ) : (
+            <div className="h-[1px] w-full" />
+          )}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/shared/hooks/use-infinite-scroll-trigger.ts
+++ b/src/shared/hooks/use-infinite-scroll-trigger.ts
@@ -12,10 +12,15 @@ export function useInfiniteScrollTrigger({
   rootMargin = '320px',
 }: UseInfiniteScrollTriggerParams) {
   const targetRef = useRef<HTMLDivElement | null>(null);
+  const onLoadMoreRef = useRef(onLoadMore);
+  const triggeredWhileVisibleRef = useRef(false);
+
+  onLoadMoreRef.current = onLoadMore;
 
   useEffect(() => {
     const target = targetRef.current;
     if (!enabled || !target) {
+      triggeredWhileVisibleRef.current = false;
       return;
     }
 
@@ -23,12 +28,22 @@ export function useInfiniteScrollTrigger({
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
-        if (!entry?.isIntersecting || locked) {
+        if (!entry) {
+          return;
+        }
+
+        if (!entry.isIntersecting) {
+          triggeredWhileVisibleRef.current = false;
+          return;
+        }
+
+        if (locked || triggeredWhileVisibleRef.current) {
           return;
         }
 
         locked = true;
-        void Promise.resolve(onLoadMore()).finally(() => {
+        triggeredWhileVisibleRef.current = true;
+        void Promise.resolve(onLoadMoreRef.current()).finally(() => {
           locked = false;
         });
       },
@@ -40,7 +55,7 @@ export function useInfiniteScrollTrigger({
     return () => {
       observer.disconnect();
     };
-  }, [enabled, onLoadMore, rootMargin]);
+  }, [enabled, rootMargin]);
 
   return targetRef;
 }

--- a/src/shared/hooks/use-infinite-scroll-trigger.ts
+++ b/src/shared/hooks/use-infinite-scroll-trigger.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+
+type UseInfiniteScrollTriggerParams = {
+  enabled: boolean;
+  onLoadMore: () => Promise<unknown> | unknown;
+  rootMargin?: string;
+};
+
+export function useInfiniteScrollTrigger({
+  enabled,
+  onLoadMore,
+  rootMargin = '320px',
+}: UseInfiniteScrollTriggerParams) {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!enabled || !target) {
+      return;
+    }
+
+    let locked = false;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry?.isIntersecting || locked) {
+          return;
+        }
+
+        locked = true;
+        void Promise.resolve(onLoadMore()).finally(() => {
+          locked = false;
+        });
+      },
+      { rootMargin },
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [enabled, onLoadMore, rootMargin]);
+
+  return targetRef;
+}

--- a/src/shared/hooks/use-notice-section.ts
+++ b/src/shared/hooks/use-notice-section.ts
@@ -72,10 +72,13 @@ export function useNoticeSection({
       return notices;
     }
 
-    return (noticeQuery.data?.pages ?? []).flatMap((page) =>
-      (((page.data as NoticeCursorResponse | undefined)?.content ??
+    return (noticeQuery.data?.pages ?? []).reduce<NoticeItem[]>((acc, page) => {
+      const pageItems =
+        (page.data as NoticeCursorResponse | undefined)?.content ??
         page.data?.notices ??
-        [])).map((notice) => {
+        [];
+
+      const mappedItems = pageItems.map((notice) => {
         const plainTextPreview = stripHtmlToText(
           (notice as typeof notice & NoticeListItemWithContext).context ?? '',
         );
@@ -89,8 +92,10 @@ export function useNoticeSection({
           views: notice.viewCount ?? 0,
           dateLabel: formatNoticeDate(notice.noticeCreateDate),
         };
-      }),
-    );
+      });
+
+      return [...acc, ...mappedItems];
+    }, []);
   }, [noticeQuery.data?.pages, notices]);
 
   const normalizedKeyword = searchKeyword.trim().toLowerCase();

--- a/src/shared/hooks/use-notice-section.ts
+++ b/src/shared/hooks/use-notice-section.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useGetNotices } from '@apis/telegro';
+import { useInfiniteNotices } from '@apis/telegro';
 import { stripHtmlToText } from '@utils/html';
 
 export type NoticeItem = {
@@ -25,6 +25,19 @@ type NoticeListItemWithContext = {
   context?: string | null;
 };
 
+type NoticeCursorResponse = {
+  hasNext?: boolean;
+  nextCursor?: unknown;
+  totalElements?: number;
+  content?: Array<{
+    id?: number;
+    noticeTitle?: string;
+    noticeCreateDate?: string;
+    viewCount?: number;
+    context?: string | null;
+  }>;
+};
+
 const formatNoticeDate = (value?: string) => {
   if (!value) return '-';
 
@@ -47,39 +60,41 @@ export function useNoticeSection({
   searchKeyword = '',
 }: UseNoticeSectionParams = {}) {
   const hasInjectedNotices = Boolean(notices?.length);
-  const noticeQuery = useGetNotices(
-    { page: 0, size: pageSize },
+  const noticeQuery = useInfiniteNotices(
+    { size: pageSize },
     {
-      query: {
-        staleTime: 60_000,
-      },
+      staleTime: 60_000,
     },
   );
 
-  const resolvedNotices = useMemo(() => {
+  const resolvedNotices = useMemo<NoticeItem[]>(() => {
     if (notices?.length) {
       return notices;
     }
 
-    return (noticeQuery.data?.data?.notices ?? []).map((notice) => {
-      const plainTextPreview = stripHtmlToText(
-        (notice as typeof notice & NoticeListItemWithContext).context ?? '',
-      );
+    return (noticeQuery.data?.pages ?? []).flatMap((page) =>
+      (((page.data as NoticeCursorResponse | undefined)?.content ??
+        page.data?.notices ??
+        [])).map((notice) => {
+        const plainTextPreview = stripHtmlToText(
+          (notice as typeof notice & NoticeListItemWithContext).context ?? '',
+        );
 
-      return {
-        id: notice.id ?? 0,
-        title:
-          notice.noticeTitle?.trim() ||
-          '\uC81C\uBAA9 \uC5C6\uB294 \uACF5\uC9C0\uC0AC\uD56D',
-        preview: plainTextPreview || FALLBACK_PREVIEW,
-        views: notice.viewCount ?? 0,
-        dateLabel: formatNoticeDate(notice.noticeCreateDate),
-      };
-    });
-  }, [noticeQuery.data?.data?.notices, notices]);
+        return {
+          id: notice.id ?? 0,
+          title:
+            notice.noticeTitle?.trim() ||
+            '\uC81C\uBAA9 \uC5C6\uB294 \uACF5\uC9C0\uC0AC\uD56D',
+          preview: plainTextPreview || FALLBACK_PREVIEW,
+          views: notice.viewCount ?? 0,
+          dateLabel: formatNoticeDate(notice.noticeCreateDate),
+        };
+      }),
+    );
+  }, [noticeQuery.data?.pages, notices]);
 
   const normalizedKeyword = searchKeyword.trim().toLowerCase();
-  const filteredNotices = useMemo(() => {
+  const filteredNotices = useMemo<NoticeItem[]>(() => {
     if (!normalizedKeyword) {
       return resolvedNotices;
     }
@@ -96,6 +111,11 @@ export function useNoticeSection({
     notices: filteredNotices,
     isLoading: hasInjectedNotices ? false : noticeQuery.isLoading,
     isError: hasInjectedNotices ? false : noticeQuery.isError,
+    hasNextPage: hasInjectedNotices ? false : Boolean(noticeQuery.hasNextPage),
+    isFetchingNextPage: hasInjectedNotices ? false : noticeQuery.isFetchingNextPage,
+    fetchNextPage: hasInjectedNotices
+      ? async () => undefined
+      : () => noticeQuery.fetchNextPage(),
     handleClickAll: () => {
       onClickAll?.();
     },

--- a/src/shared/hooks/use-order-list.ts
+++ b/src/shared/hooks/use-order-list.ts
@@ -1,7 +1,7 @@
+import { useInfiniteOrders } from '@apis/telegro';
 import type { OrderDetailDTO } from '@apis/telegro';
-import { useGetOrders } from '@apis/telegro';
-import { getOrderStatusLabel } from '@constants/orderStatus';
 import type { OrderRow, OrderStatusValue } from '@components/order/order-list-table';
+import { getOrderStatusLabel } from '@constants/orderStatus';
 import { formatNumber } from '@utils/format';
 import { useMemo } from 'react';
 
@@ -13,14 +13,14 @@ type UseOrderListParams = {
   filterBy?: OrderFilterType;
 };
 
-const DEFAULT_PAGE_SIZE = 10000;
+const DEFAULT_PAGE_SIZE = 10;
 
 const formatPrice = (value?: number | null) => {
   if (value === undefined || value === null) {
     return '-';
   }
 
-  return `${formatNumber(value)}원`;
+  return `${formatNumber(value)} KRW`;
 };
 
 const formatProductName = (order: OrderDetailDTO) => {
@@ -28,11 +28,11 @@ const formatProductName = (order: OrderDetailDTO) => {
   const firstProductName = products[0]?.productName?.trim();
 
   if (!firstProductName) {
-    return '상품 정보 없음';
+    return 'Unknown product';
   }
 
   return products.length > 1
-    ? `${firstProductName} 외 ${products.length - 1}건`
+    ? `${firstProductName} +${products.length - 1}`
     : firstProductName;
 };
 
@@ -47,16 +47,10 @@ const formatOptionLabel = (order: OrderDetailDTO) => {
   return optionValues.length ? optionValues.join(' / ') : '-';
 };
 
-const getQuantity = (order: OrderDetailDTO) => {
-  return (order.products ?? []).reduce(
-    (sum, product) => sum + (product.quantity ?? 0),
-    0,
-  );
-};
+const getQuantity = (order: OrderDetailDTO) =>
+  (order.products ?? []).reduce((sum, product) => sum + (product.quantity ?? 0), 0);
 
-const getUnitPrice = (order: OrderDetailDTO) => {
-  return formatPrice(order.products?.[0]?.productPrice);
-};
+const getUnitPrice = (order: OrderDetailDTO) => formatPrice(order.products?.[0]?.productPrice);
 
 const getOrderInfo = (order: OrderDetailDTO) => {
   if (!order.createdAt) {
@@ -64,7 +58,6 @@ const getOrderInfo = (order: OrderDetailDTO) => {
   }
 
   const date = new Date(order.createdAt);
-
   if (Number.isNaN(date.getTime())) {
     return '-';
   }
@@ -78,13 +71,10 @@ const getOrderInfo = (order: OrderDetailDTO) => {
   return `${year}-${month}-${day} ${hours}:${minutes}`;
 };
 
-const getCustomerInfo = (order: OrderDetailDTO) => {
-  return order.userInfo?.username?.trim() || '-';
-};
+const getCustomerInfo = (order: OrderDetailDTO) => order.userInfo?.username?.trim() || '-';
 
-const getStatusValue = (order: OrderDetailDTO): OrderStatusValue => {
-  return (order.orderStatus as OrderStatusValue | undefined) ?? 'ORDER_CREATED';
-};
+const getStatusValue = (order: OrderDetailDTO): OrderStatusValue =>
+  (order.orderStatus as OrderStatusValue | undefined) ?? 'ORDER_CREATED';
 
 export const useOrderList = ({
   pageSize = DEFAULT_PAGE_SIZE,
@@ -94,46 +84,56 @@ export const useOrderList = ({
   const normalizedKeyword = searchKeyword.trim();
   const hasSearchKeyword = normalizedKeyword.length > 0;
 
-  const orderQuery = useGetOrders(
+  const orderQuery = useInfiniteOrders(
     {
       size: pageSize,
       q: hasSearchKeyword ? normalizedKeyword : undefined,
       filterBy: hasSearchKeyword ? filterBy : undefined,
     },
     {
-      query: {
-        staleTime: 60_000,
-      },
+      staleTime: 60_000,
     },
   );
 
-  const orders = useMemo<OrderRow[]>(() => {
-    return (orderQuery.data?.data?.orders ?? []).map((order, index) => ({
-      id: order.orderId ?? index + 1,
-      orderId: order.orderId ?? index + 1,
-      productName: formatProductName(order),
-      optionLabel: formatOptionLabel(order),
-      quantity: getQuantity(order),
-      unitPrice: getUnitPrice(order),
-      totalPrice: formatPrice(order.amount),
-      totalSubLabel:
-        order.shoppingCost === 0
-          ? '(무료배송)'
-          : order.shoppingCost
-            ? `배송비 ${formatPrice(order.shoppingCost)}`
-            : undefined,
-      orderInfo: getOrderInfo(order),
-      customerInfo: getCustomerInfo(order),
-      statusLabel: getOrderStatusLabel(order.orderStatus),
-      statusValue: getStatusValue(order),
-    }));
-  }, [orderQuery.data?.data?.orders]);
+  const orders = useMemo<OrderRow[]>(
+    () =>
+      (orderQuery.data?.pages ?? []).flatMap((page, pageIndex) =>
+        (page.data?.data?.orders ?? []).map((order, index) => ({
+          id: order.orderId ?? pageIndex * pageSize + index + 1,
+          orderId: order.orderId ?? pageIndex * pageSize + index + 1,
+          productName: formatProductName(order),
+          optionLabel: formatOptionLabel(order),
+          quantity: getQuantity(order),
+          unitPrice: getUnitPrice(order),
+          totalPrice: formatPrice(order.amount),
+          totalSubLabel:
+            order.shoppingCost === 0
+              ? '(Free shipping)'
+              : order.shoppingCost
+                ? `Shipping ${formatPrice(order.shoppingCost)}`
+                : undefined,
+          orderInfo: getOrderInfo(order),
+          customerInfo: getCustomerInfo(order),
+          statusLabel: getOrderStatusLabel(order.orderStatus),
+          statusValue: getStatusValue(order),
+        })),
+      ),
+    [orderQuery.data?.pages, pageSize],
+  );
+
+  const totalCount =
+    orderQuery.data?.pages.at(-1)?.data?.data?.totalElement ??
+    orderQuery.data?.pages[0]?.data?.data?.totalElement ??
+    orders.length;
 
   return {
     orders,
-    totalCount: orderQuery.data?.data?.totalElement ?? orders.length,
+    totalCount,
     isLoading: orderQuery.isLoading,
     isError: orderQuery.isError,
+    hasNextPage: Boolean(orderQuery.hasNextPage),
+    isFetchingNextPage: orderQuery.isFetchingNextPage,
+    fetchNextPage: () => orderQuery.fetchNextPage(),
     refetch: orderQuery.refetch,
   };
 };

--- a/src/shared/hooks/use-order-list.ts
+++ b/src/shared/hooks/use-order-list.ts
@@ -76,6 +76,45 @@ const getCustomerInfo = (order: OrderDetailDTO) => order.userInfo?.username?.tri
 const getStatusValue = (order: OrderDetailDTO): OrderStatusValue =>
   (order.orderStatus as OrderStatusValue | undefined) ?? 'ORDER_CREATED';
 
+type OrderPageData = {
+  content?: OrderDetailDTO[];
+  orders?:
+    | OrderDetailDTO[]
+    | {
+        content?: OrderDetailDTO[];
+        totalElement?: number;
+        totalElements?: number;
+      };
+  totalElement?: number;
+  totalElements?: number;
+};
+
+const getPageOrders = (page: {
+  data?: OrderPageData;
+}) => {
+  const { data } = page;
+
+  if (Array.isArray(data?.content)) {
+    return data.content;
+  }
+
+  if (Array.isArray(data?.orders)) {
+    return data.orders;
+  }
+
+  if (Array.isArray(data?.orders?.content)) {
+    return data.orders.content;
+  }
+
+  return [];
+};
+
+const getPageTotalCount = (page?: { data?: OrderPageData }) =>
+  page?.data?.totalElements ??
+  page?.data?.totalElement ??
+  (Array.isArray(page?.data?.orders) ? undefined : page?.data?.orders?.totalElements) ??
+  (Array.isArray(page?.data?.orders) ? undefined : page?.data?.orders?.totalElement);
+
 export const useOrderList = ({
   pageSize = DEFAULT_PAGE_SIZE,
   searchKeyword = '',
@@ -96,9 +135,9 @@ export const useOrderList = ({
   );
 
   const orders = useMemo<OrderRow[]>(
-    () =>
-      (orderQuery.data?.pages ?? []).flatMap((page, pageIndex) =>
-        (page.data?.data?.orders ?? []).map((order, index) => ({
+    () => {
+      const rows = (orderQuery.data?.pages ?? []).reduce<OrderRow[]>((acc, page, pageIndex) => {
+        const rows = getPageOrders(page).map((order, index) => ({
           id: order.orderId ?? pageIndex * pageSize + index + 1,
           orderId: order.orderId ?? pageIndex * pageSize + index + 1,
           productName: formatProductName(order),
@@ -116,14 +155,27 @@ export const useOrderList = ({
           customerInfo: getCustomerInfo(order),
           statusLabel: getOrderStatusLabel(order.orderStatus),
           statusValue: getStatusValue(order),
-        })),
-      ),
+        }));
+
+        return [...acc, ...rows];
+      }, []);
+
+      return rows.reduce<OrderRow[]>((acc, row) => {
+        if (acc.some((currentRow) => currentRow.orderId === row.orderId)) {
+          return acc;
+        }
+
+        return [...acc, row];
+      }, []);
+    },
     [orderQuery.data?.pages, pageSize],
   );
 
+  const pages = orderQuery.data?.pages ?? [];
+  const lastPage = pages.length ? pages[pages.length - 1] : undefined;
   const totalCount =
-    orderQuery.data?.pages.at(-1)?.data?.data?.totalElement ??
-    orderQuery.data?.pages[0]?.data?.data?.totalElement ??
+    getPageTotalCount(lastPage) ??
+    getPageTotalCount(pages[0]) ??
     orders.length;
 
   return {

--- a/src/shared/hooks/use-product-section.ts
+++ b/src/shared/hooks/use-product-section.ts
@@ -1,7 +1,9 @@
-import { telegroPrefetch, useGetProducts, type GetProductsCategory } from '@apis/telegro';
+import {
+  useInfiniteProducts,
+  type GetProductsCategory,
+} from '@apis/telegro';
 import { formatPrice } from '@utils/format';
-import { useEffect, useMemo, useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
 
 export type ProductCategory = GetProductsCategory;
 
@@ -22,6 +24,7 @@ type UseProductSectionParams = {
   onClickProduct?: (product: ProductItem) => void;
   pageSize?: number;
   searchKeyword?: string;
+  variant?: 'dashboard' | 'list';
 };
 
 const DEFAULT_PAGE_SIZE = 4;
@@ -39,16 +42,6 @@ const CATEGORY_LABELS: Record<ProductCategory, string> = {
   RECORDER: '\uB179\uC74C\uAE30\uAE30',
   ACCESSORY: '\uC545\uC138\uC11C\uB9AC',
 };
-
-const getProductPageParams = (
-  category: ProductCategory,
-  page: number,
-  pageSize: number,
-) => ({
-  category,
-  page,
-  size: pageSize,
-});
 
 const toProductItem = (
   category: ProductCategory,
@@ -79,12 +72,12 @@ export function useProductSection({
   onClickProduct,
   pageSize = DEFAULT_PAGE_SIZE,
   searchKeyword = '',
+  variant = 'dashboard',
 }: UseProductSectionParams = {}) {
-  const queryClient = useQueryClient();
   const hasInjectedProducts = Boolean(products?.length);
   const [activeCategory, setActiveCategory] =
     useState<ProductCategory>(initialCategory);
-  const [pageByCategory, setPageByCategory] = useState<Record<ProductCategory, number>>({
+  const [pageIndexByCategory, setPageIndexByCategory] = useState<Record<ProductCategory, number>>({
     HEADSET: 0,
     PHONE_AMP: 0,
     LINE_CORD: 0,
@@ -92,37 +85,38 @@ export function useProductSection({
     ACCESSORY: 0,
   });
 
-  const currentPage = pageByCategory[activeCategory];
-  const productQuery = useGetProducts(getProductPageParams(activeCategory, currentPage, pageSize), {
-    query: {
+  const currentPageIndex = pageIndexByCategory[activeCategory];
+  const productQuery = useInfiniteProducts(
+    {
+      category: activeCategory,
+      size: pageSize,
+    },
+    {
       staleTime: 60_000,
     },
-  });
+  );
 
-  useEffect(() => {
-    CATEGORY_OPTIONS.forEach((category) => {
-      void telegroPrefetch.products(queryClient, getProductPageParams(category, 0, pageSize));
-    });
-  }, [pageSize, queryClient]);
-
-  useEffect(() => {
-    if (!productQuery.data?.data?.isLast) {
-      void telegroPrefetch.products(
-        queryClient,
-        getProductPageParams(activeCategory, currentPage + 1, pageSize),
-      );
-    }
-  }, [activeCategory, currentPage, pageSize, productQuery.data?.data?.isLast, queryClient]);
+  const mappedPages = useMemo(
+    () =>
+      (productQuery.data?.pages ?? []).map((page) =>
+        (page.data?.data?.products ?? []).map((product) =>
+          toProductItem(activeCategory, product),
+        ),
+      ),
+    [activeCategory, productQuery.data?.pages],
+  );
 
   const resolvedProducts = useMemo(() => {
     if (products?.length) {
       return products.filter((product) => product.category === activeCategory);
     }
 
-    return (productQuery.data?.data?.products ?? []).map((product) =>
-      toProductItem(activeCategory, product),
-    );
-  }, [activeCategory, productQuery.data?.data?.products, products]);
+    if (variant === 'dashboard') {
+      return mappedPages[currentPageIndex] ?? [];
+    }
+
+    return mappedPages.flat();
+  }, [activeCategory, currentPageIndex, mappedPages, products, variant]);
 
   const normalizedKeyword = searchKeyword.trim().toLowerCase();
   const filteredProducts = useMemo(() => {
@@ -145,15 +139,32 @@ export function useProductSection({
       return;
     }
 
-    if (productQuery.data?.data?.isLast) {
+    const nextPageIndex = currentPageIndex + 1;
+    const loadedPageCount = mappedPages.length;
+
+    if (nextPageIndex < loadedPageCount) {
+      setPageIndexByCategory((prev) => ({
+        ...prev,
+        [activeCategory]: nextPageIndex,
+      }));
+      onClickArrow?.();
       return;
     }
 
-    setPageByCategory((prev) => ({
-      ...prev,
-      [activeCategory]: prev[activeCategory] + 1,
-    }));
-    onClickArrow?.();
+    if (!productQuery.hasNextPage || productQuery.isFetchingNextPage) {
+      return;
+    }
+
+    void productQuery.fetchNextPage().then((result) => {
+      const fetchedPageCount = result.data?.pages.length ?? loadedPageCount;
+      if (nextPageIndex < fetchedPageCount) {
+        setPageIndexByCategory((prev) => ({
+          ...prev,
+          [activeCategory]: nextPageIndex,
+        }));
+      }
+      onClickArrow?.();
+    });
   };
 
   return {
@@ -167,7 +178,12 @@ export function useProductSection({
     isError: hasInjectedProducts ? false : productQuery.isError,
     isArrowDisabled: hasInjectedProducts
       ? filteredProducts.length <= pageSize
-      : Boolean(productQuery.data?.data?.isLast),
+      : !productQuery.hasNextPage && currentPageIndex >= Math.max(mappedPages.length - 1, 0),
+    hasNextPage: hasInjectedProducts ? false : Boolean(productQuery.hasNextPage),
+    isFetchingNextPage: hasInjectedProducts ? false : productQuery.isFetchingNextPage,
+    fetchNextPage: hasInjectedProducts
+      ? async () => undefined
+      : () => productQuery.fetchNextPage(),
     setActiveCategory: handleChangeCategory,
     handleClickAll: () => onClickAll?.(),
     handleClickArrow,

--- a/src/shared/hooks/use-product-section.ts
+++ b/src/shared/hooks/use-product-section.ts
@@ -64,6 +64,25 @@ const toProductItem = (
   imageSrc: product.coverImage?.trim() || '/product1.png',
 });
 
+const getPageProducts = (page: {
+  data?: {
+    content?: Array<{
+      id?: number;
+      productModel?: string;
+      productName?: string;
+      price?: string;
+      coverImage?: string;
+    }>;
+    products?: Array<{
+      id?: number;
+      productModel?: string;
+      productName?: string;
+      price?: string;
+      coverImage?: string;
+    }>;
+  };
+}) => page.data?.content ?? page.data?.products ?? [];
+
 export function useProductSection({
   initialCategory = 'HEADSET',
   products,
@@ -99,7 +118,7 @@ export function useProductSection({
   const mappedPages = useMemo(
     () =>
       (productQuery.data?.pages ?? []).map((page) =>
-        (page.data?.data?.products ?? []).map((product) =>
+        getPageProducts(page).map((product) =>
           toProductItem(activeCategory, product),
         ),
       ),
@@ -115,7 +134,10 @@ export function useProductSection({
       return mappedPages[currentPageIndex] ?? [];
     }
 
-    return mappedPages.flat();
+    return mappedPages.reduce<ProductItem[]>(
+      (acc, currentPage) => [...acc, ...currentPage],
+      [],
+    );
   }, [activeCategory, currentPageIndex, mappedPages, products, variant]);
 
   const normalizedKeyword = searchKeyword.trim().toLowerCase();


### PR DESCRIPTION
 Closes #52                                                                                                                          
                                                                                                                                      
  ## 🔎 설명                                                                                                                          
                                                                                                                                      
백엔드 API가 페이지 기반에서 커서 기반으로 변경된 엔드포인트에 맞춰 프론트 목록 조회 로직을 수정했습니다.                           
상품, 공지사항, 주문, 장바구니에 대해 커서 기반 infinite query를 별도 래퍼로 구성하고, 화면에서는 Intersection Observer 기반 무한 스크롤로 다음 페이지를 불러오도록 반영했습니다.                                                                                       

추가로 401 응답 시 에러 페이지 대신 홈으로 이동하도록 공통 axios 응답 처리도 정리했습니다.                                          
                                                                                                                                      
  ## 🚀 해결한 TODO                                                                                                                   
                                                                                                                                      
  - [x] 상품/공지/주문/장바구니 커서 기반 조회 로직 추가                                                                              
  - [x] 공지/주문/상품 목록 화면에 무한 스크롤 적용                                                                                   
  - [x] 장바구니/주문/공지 응답 shape 차이 대응 및 401 리다이렉트 처리                                                                
                                                                                                                                      
  ##  상세 설명💎                                                                                                                     
                                                                                                                                      
  - `src/shared/apis/telegro/cursor.ts`                                                                                               
    - `/products`, `/notices`, `/api/orders`, `/api/carts`용 커서 조회 래퍼 및 `useInfiniteQuery` 훅 추가                             
    - 응답마다 다른 `content`, `products`, `orders`, `carts.content` 구조를 공통적으로 파싱하도록 처리                                
    - `cursorId`, `cursorCreatedAt`, `nextCursorId`, `nextCursorCreatedAt` 기반으로 다음 페이지 파라미터 계산                         
    - 중복 커서 재호출 방지 로직 추가                                                                                                 
                                                                                                                                      
  - `src/shared/hooks/use-infinite-scroll-trigger.ts`                                                                                 
    - Intersection Observer 기반 공통 무한 스크롤 훅 추가                                                                             
    - 동일 sentinel 노출 상태에서 중복 호출되지 않도록 제어                                                                           
                                                                                                                                      
  - 상품                                                                                                                              
    - `use-product-section.ts`                                                                                                        
    - `product-section-container.tsx`                                                                                                 
    - `product-section-view.tsx`                                                                                                      
    - 상품 리스트를 커서 기반으로 변경하고, 목록형 화면에서 스크롤 시 추가 로딩되도록 반영                                            
                                                                                                                                      
  - 공지                                                                                                                              
    - `use-notice-section.ts`                                                                                                         
    - `src/pages/public/notices/notices.tsx`                                                                                          
    - `src/pages/admin/notices/notices.tsx`                                                                                           
    - 공지 응답 `content` 구조를 읽도록 수정하고, 사용자/관리자 공지 목록 모두 무한 스크롤 적용                                       
                                                                                                                                      
  - 주문                                                                                                                              
    - `use-order-list.ts`
    - `src/pages/app/orders/orders.tsx`                                                                                               
    - `src/pages/admin/orders/orders.tsx`                                                                                             
    - 주문 응답 구조 차이를 흡수하면서 무한 스크롤로 다음 주문 목록을 조회하도록 수정                                                 
    - 중복 주문 렌더로 인한 key 경고 대응                                                                                             
                                                                                                                                      
  - 장바구니                                                                                                                          
    - `use-cart-items-query.ts`                                                                                                       
    - 커서 기반 장바구니 목록을 끝까지 순차 조회해 화면 데이터로 변환하도록 수정                                                      
                                                                                                                                      
  - 기타                                                                                                                              
    - `axios-instance.ts`: 인증 만료(401) 시 토큰 제거 후 `/`로 이동하도록 공통 처리                                                  
    - `index.ts`: 커서 API export 추가                                                                                                
    - `use-my-page.ts`: 최근 주문 조회에서 제거된 `page` 파라미터 반영                                                                
                                                                                                                                      
  ## 💎 새롭게 알게 된 / 공부한 내용                                                                                                  
                                                                                                                                      
  - Orval 생성 타입이 최신 커서 응답 shape를 아직 반영하지 못하는 경우, 생성 코드를 바로 수정하기보다 별도 래퍼 계층을 두는 방식이 안전했습니다.                                                                                                                         
  - React Query의 `useInfiniteQuery`는 API별 응답 구조가 달라도 `getNextPageParam`을 분리하면 화면 훅은 일관된 방식으로 유지할 수 있었습니다.                                                                                                                             
  - 커서 기반 목록에서는 단순 `hasNext`만 믿지 않고, 중복 커서/중복 아이템 방어 로직도 같이 필요했습니다.                      
                                                                                                                                      
  ## 📷 Screenshots or Video                                                                                                          
                                                                                                                                      
  UI 구조 변경보다 API 조회 방식과 스크롤 로직 변경이 중심인 작업이라 별도 스크린샷은 생략했습니다.   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Infinite scroll pagination added to product lists, order lists, and notice lists.
  * Automatic "Load More" triggering when scrolling to bottom of lists.
  * Loading indicators display during pagination fetch operations.

* **Bug Fixes**
  * Fixed unauthorized session handling to properly redirect and clear stored credentials.

* **Performance Improvements**
  * Reduced initial data loads by fetching smaller page sizes incrementally instead of large single batches.
  * Cart items now load on-demand for faster initial page performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->