### PR TITLE
[Feat/#55] 모바일 헤더 UI 구현 (All)

### DIFF
--- a/src/pages/app/my/use-my-page.ts
+++ b/src/pages/app/my/use-my-page.ts
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import {
   telegroInvalidate,
   type DeliveryAddressDetailDTO,
+  type OrderDetailDTO,
   useAddDeliveryAddress,
   useAddDeliveryAddress1 as useDeleteDeliveryAddress,
   useGetMyPage,
@@ -16,6 +17,25 @@ import { INITIAL_ADDRESS_FORM, POSTCODE_SCRIPT_ID, POSTCODE_SCRIPT_SRC } from '.
 import type { AddressForm, AddressModalState, MenuItem } from './my.types';
 import { buildRoadAddress, getAddressForm, getApiErrorMessage, getDefaultAddress, toAddressPayload } from './my.utils';
 
+const getRecentOrders = (
+  orders:
+    | OrderDetailDTO[]
+    | {
+        content?: OrderDetailDTO[];
+      }
+    | undefined,
+) => {
+  if (Array.isArray(orders)) {
+    return orders;
+  }
+
+  if (Array.isArray(orders?.content)) {
+    return orders.content;
+  }
+
+  return [];
+};
+
 export function useMyPage() {
   const queryClient = useQueryClient();
   const [activeMenu, setActiveMenu] = useState<MenuItem>('프로필');
@@ -26,7 +46,7 @@ export function useMyPage() {
   const [addressForm, setAddressForm] = useState<AddressForm>(INITIAL_ADDRESS_FORM);
 
   const myPageQuery = useGetMyPage({ query: { staleTime: 60_000 } });
-  const ordersQuery = useGetOrders({ size: 4 }, { query: { staleTime: 60_000 } });
+  const ordersQuery = useGetOrders({ size: 5 }, { query: { staleTime: 60_000 } });
   const addAddressMutation = useAddDeliveryAddress();
   const updateAddressMutation = useUpdateDeliveryAddress();
   const deleteAddressMutation = useDeleteDeliveryAddress();
@@ -59,7 +79,7 @@ export function useMyPage() {
   const user = myPageQuery.data?.data;
   const addresses = [...(user?.addressList ?? [])].sort((a, b) => Number(b.isDefault) - Number(a.isDefault));
   const defaultAddress = getDefaultAddress(addresses);
-  const recentOrders = ordersQuery.data?.data?.orders ?? [];
+  const recentOrders = getRecentOrders(ordersQuery.data?.data?.orders);
 
   const isAddressMutationPending =
     addAddressMutation.isPending ||

--- a/src/shared/layouts/admin-layout.tsx
+++ b/src/shared/layouts/admin-layout.tsx
@@ -24,7 +24,9 @@ const AdminLayout = () => {
             <div className="hidden items-center gap-[1.2rem] max-[500px]:flex">
               <button
                 type="button"
-                aria-label={isMobileMenuOpen ? '관리자 메뉴 닫기' : '관리자 메뉴 열기'}
+                aria-label={
+                  isMobileMenuOpen ? '관리자 메뉴 닫기' : '관리자 메뉴 열기'
+                }
                 aria-expanded={isMobileMenuOpen}
                 aria-controls="admin-mobile-menu"
                 onClick={() => setIsMobileMenuOpen((prev) => !prev)}
@@ -32,7 +34,10 @@ const AdminLayout = () => {
               >
                 {isMobileMenuOpen ? <FiX size={22} /> : <FiMenu size={22} />}
               </button>
-              <Link to="/admin" className="title3_bold text-primary no-underline">
+              <Link
+                to="/admin"
+                className="title3_bold text-primary no-underline"
+              >
                 Telegro
               </Link>
             </div>
@@ -40,27 +45,38 @@ const AdminLayout = () => {
             <Link to="/admin" className={`${linkClass} max-[500px]:hidden`}>
               Dashboard
             </Link>
-            <Link to="/admin/users" className={`${linkClass} max-[500px]:hidden`}>
-              Users
+            <Link
+              to="/admin/users"
+              className={`${linkClass} max-[500px]:hidden`}
+            >
+              사용자 목록
             </Link>
             <Link
               to="/admin/products"
               className={`${linkClass} max-[500px]:hidden`}
             >
-              Product
+              상품 목록
             </Link>
-            <Link to="/admin/orders" className={`${linkClass} max-[500px]:hidden`}>
-              Order
+            <Link
+              to="/admin/orders"
+              className={`${linkClass} max-[500px]:hidden`}
+            >
+              주문 목록
             </Link>
-            <Link to="/admin/notices" className={`${linkClass} max-[500px]:hidden`}>
-              Notice
+            <Link
+              to="/admin/notices"
+              className={`${linkClass} max-[500px]:hidden`}
+            >
+              공지사항
             </Link>
           </div>
 
           <div
             id="admin-mobile-menu"
             className={`hidden overflow-hidden transition-all duration-300 ease-out max-[500px]:mt-[1.2rem] max-[500px]:block ${
-              isMobileMenuOpen ? 'max-[500px]:max-h-[32rem]' : 'max-[500px]:max-h-0'
+              isMobileMenuOpen
+                ? 'max-[500px]:max-h-[32rem]'
+                : 'max-[500px]:max-h-0'
             }`}
           >
             <div className="flex flex-col gap-[0.8rem] border-t border-[#f0f0f0] pt-[1.2rem]">
@@ -68,16 +84,16 @@ const AdminLayout = () => {
                 Dashboard
               </Link>
               <Link to="/admin/users" className={mobileLinkClass}>
-                Users
+                사용자 목록
               </Link>
               <Link to="/admin/products" className={mobileLinkClass}>
-                Product
+                상품 목록
               </Link>
               <Link to="/admin/orders" className={mobileLinkClass}>
-                Order
+                주문 목록
               </Link>
               <Link to="/admin/notices" className={mobileLinkClass}>
-                Notice
+                공지사항
               </Link>
             </div>
           </div>

--- a/src/shared/layouts/admin-layout.tsx
+++ b/src/shared/layouts/admin-layout.tsx
@@ -1,28 +1,86 @@
-import { Outlet, Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { FiMenu, FiX } from 'react-icons/fi';
+import { Outlet, Link, useLocation } from 'react-router-dom';
 
 const linkClass =
   'title6 text-gray-900 no-underline transition-underline hover:underline';
 
+const mobileLinkClass =
+  'title6 rounded-[1rem] px-[0.6rem] py-[0.8rem] text-gray-900 no-underline transition-underline hover:underline';
+
 const AdminLayout = () => {
+  const location = useLocation();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setIsMobileMenuOpen(false);
+  }, [location.pathname]);
+
   return (
     <div className="min-h-screen bg-white">
-      <header className="fixed top-0 z-50 w-full border-b border-[#eee] bg-white px-[3rem] py-[1.6rem]">
-        <nav className="flex gap-[3rem] px-[3rem]">
-          <Link to="/admin" className={linkClass}>
-            Dashboard
-          </Link>
-          <Link to="/admin/users" className={linkClass}>
-            Users
-          </Link>
-          <Link to="/admin/products" className={linkClass}>
-            Product
-          </Link>
-          <Link to="/admin/orders" className={linkClass}>
-            Order
-          </Link>
-          <Link to="/admin/notices" className={linkClass}>
-            Notice
-          </Link>
+      <header className="fixed top-0 z-50 w-full border-b border-[#eee] bg-white px-[3rem] py-[1.6rem] max-[500px]:px-[1.6rem] max-[500px]:py-[1.2rem]">
+        <nav className="px-[3rem] max-[500px]:px-0">
+          <div className="flex gap-[3rem] max-[500px]:justify-between max-[500px]:gap-[1.2rem]">
+            <div className="hidden items-center gap-[1.2rem] max-[500px]:flex">
+              <button
+                type="button"
+                aria-label={isMobileMenuOpen ? '관리자 메뉴 닫기' : '관리자 메뉴 열기'}
+                aria-expanded={isMobileMenuOpen}
+                aria-controls="admin-mobile-menu"
+                onClick={() => setIsMobileMenuOpen((prev) => !prev)}
+                className="rounded-full p-[0.6rem] text-[#121212] transition-colors hover:bg-black/5"
+              >
+                {isMobileMenuOpen ? <FiX size={22} /> : <FiMenu size={22} />}
+              </button>
+              <Link to="/admin" className="title3_bold text-primary no-underline">
+                Telegro
+              </Link>
+            </div>
+
+            <Link to="/admin" className={`${linkClass} max-[500px]:hidden`}>
+              Dashboard
+            </Link>
+            <Link to="/admin/users" className={`${linkClass} max-[500px]:hidden`}>
+              Users
+            </Link>
+            <Link
+              to="/admin/products"
+              className={`${linkClass} max-[500px]:hidden`}
+            >
+              Product
+            </Link>
+            <Link to="/admin/orders" className={`${linkClass} max-[500px]:hidden`}>
+              Order
+            </Link>
+            <Link to="/admin/notices" className={`${linkClass} max-[500px]:hidden`}>
+              Notice
+            </Link>
+          </div>
+
+          <div
+            id="admin-mobile-menu"
+            className={`hidden overflow-hidden transition-all duration-300 ease-out max-[500px]:mt-[1.2rem] max-[500px]:block ${
+              isMobileMenuOpen ? 'max-[500px]:max-h-[32rem]' : 'max-[500px]:max-h-0'
+            }`}
+          >
+            <div className="flex flex-col gap-[0.8rem] border-t border-[#f0f0f0] pt-[1.2rem]">
+              <Link to="/admin" className={mobileLinkClass}>
+                Dashboard
+              </Link>
+              <Link to="/admin/users" className={mobileLinkClass}>
+                Users
+              </Link>
+              <Link to="/admin/products" className={mobileLinkClass}>
+                Product
+              </Link>
+              <Link to="/admin/orders" className={mobileLinkClass}>
+                Order
+              </Link>
+              <Link to="/admin/notices" className={mobileLinkClass}>
+                Notice
+              </Link>
+            </div>
+          </div>
         </nav>
       </header>
 
@@ -30,7 +88,7 @@ const AdminLayout = () => {
         <Outlet />
       </main>
 
-      <footer className="border-t border-[#eee] px-3 py-3">© Admin</footer>
+      <footer className="border-t border-[#eee] px-3 py-3">짤 Admin</footer>
     </div>
   );
 };

--- a/src/shared/layouts/public-header.tsx
+++ b/src/shared/layouts/public-header.tsx
@@ -6,7 +6,8 @@ import NotificationDrawer, {
 import type { NotificationItem } from '@components/notification/notification-card';
 import { isLoggedInAtom } from '@state/session';
 import { useAtomValue } from 'jotai';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { FiMenu, FiX } from 'react-icons/fi';
 import { Link, useLocation } from 'react-router-dom';
 
 const linkClass =
@@ -26,6 +27,7 @@ const PublicHeader = () => {
   const location = useLocation();
   const [isLoginOverlayOpen, setIsLoginOverlayOpen] = useState(false);
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [notifications, setNotifications] = useState<NotificationItem[]>(
     DEFAULT_NOTIFICATION_ITEMS,
   );
@@ -35,94 +37,218 @@ const PublicHeader = () => {
     [notifications],
   );
 
+  useEffect(() => {
+    setIsMobileMenuOpen(false);
+  }, [location.pathname]);
+
   const handleClosePanels = () => {
     setIsLoginOverlayOpen(false);
     setIsNotificationOpen(false);
+    setIsMobileMenuOpen(false);
   };
+
+  const notificationButton = (
+    <>
+      <span className="relative inline-flex cursor-pointer">
+        <Icon
+          name="alarm"
+          size={3}
+          ariaHidden={false}
+          ariaLabel="Notification"
+        />
+        {unreadCount > 0 ? (
+          <span className="absolute -top-1 -right-1 inline-flex h-[1.6rem] w-[1.6rem] items-center justify-center rounded-full bg-[#FF4B4E] px-[0.45rem] py-[0.2rem] text-[1rem] leading-none font-semibold text-white">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        ) : (
+          <span className="absolute top-1 right-1 h-2.5 w-2.5 rounded-full bg-[#FF4B4E]" />
+        )}
+      </span>
+    </>
+  );
 
   return (
     <>
-      <header className="fixed top-0 z-50 w-full border-b border-[#eee] bg-white px-[3rem] py-[1.6rem]">
-        <nav className="flex items-center gap-[3rem] px-[2rem]">
-          <Link
-            to="/"
-            className={brandLinkClass}
-            onClick={handleClosePanels}
-          >
-            <span className="relative inline-block">
-              <span className={brandTextBaseClass}>Telegro</span>
-              <span aria-hidden="true" className={brandTextGradientClass}>
-                Telegro
-              </span>
-            </span>
-          </Link>
-          <Link
-            to="/products"
-            className={linkClass}
-            onClick={handleClosePanels}
-          >
-            상품
-          </Link>
-          <Link to="/notices" className={linkClass} onClick={handleClosePanels}>
-            공지사항
-          </Link>
-          <Link
-            to="/app/cart"
-            className={linkClass}
-            onClick={handleClosePanels}
-          >
-            장바구니
-          </Link>
+      <header className="fixed top-0 z-50 w-full border-b border-[#eee] bg-white px-[3rem] py-[1.6rem] max-[500px]:px-[1.6rem] max-[500px]:py-[1.2rem]">
+        <nav className="px-[2rem] max-[500px]:px-0">
+          <div className="flex items-center gap-[3rem] max-[500px]:justify-between max-[500px]:gap-[1.2rem]">
+            <div className="hidden max-[500px]:flex max-[500px]:items-center max-[500px]:gap-[1.2rem]">
+              <button
+                type="button"
+                aria-label={isMobileMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
+                aria-expanded={isMobileMenuOpen}
+                aria-controls="public-mobile-menu"
+                onClick={() => setIsMobileMenuOpen((prev) => !prev)}
+                className="rounded-full p-[0.6rem] text-[#121212] transition-colors hover:bg-black/5"
+              >
+                {isMobileMenuOpen ? <FiX size={22} /> : <FiMenu size={22} />}
+              </button>
 
-          <div className="ml-auto flex items-center gap-6">
-            {isLoggedIn ? (
-              <>
-                <button
-                  type="button"
-                  aria-label="알림 보기"
-                  aria-expanded={isNotificationOpen}
-                  aria-controls="notification-drawer"
-                  onClick={() => setIsNotificationOpen(true)}
-                  className="place-items-center rounded-full px-2 py-1 transition-colors hover:bg-black/5"
-                >
-                  <span className="relative inline-flex cursor-pointer">
-                    <Icon
-                      name="alarm"
-                      size={3}
-                      ariaHidden={false}
-                      ariaLabel="Notification"
-                    />
-                    {unreadCount > 0 ? (
-                      <span className="absolute -top-1 -right-1 inline-flex h-[1.6rem] w-[1.6rem] items-center justify-center rounded-full bg-[#FF4B4E] px-[0.45rem] py-[0.2rem] text-[1rem] leading-none font-semibold text-white">
-                        {unreadCount > 99 ? '99+' : unreadCount}
-                      </span>
-                    ) : (
-                      <span className="absolute top-1 right-1 h-2.5 w-2.5 rounded-full bg-[#FF4B4E]" />
-                    )}
+              <Link
+                to="/"
+                className={brandLinkClass}
+                onClick={handleClosePanels}
+              >
+                <span className="relative inline-block">
+                  <span className={brandTextBaseClass}>Telegro</span>
+                  <span aria-hidden="true" className={brandTextGradientClass}>
+                    Telegro
                   </span>
-                </button>
-                <Link
-                  to="/app/my"
-                  className={linkClass}
-                  onClick={handleClosePanels}
-                >
-                  마이페이지
-                </Link>
-              </>
-            ) : (
-              <>
-                <Link to="/guest/orders" className={secondaryLinkClass}>
-                  비회원 주문조회
-                </Link>
-                <button
-                  type="button"
-                  onClick={() => setIsLoginOverlayOpen(true)}
-                  className={linkClass}
-                >
-                  로그인하기
-                </button>
-              </>
-            )}
+                </span>
+              </Link>
+            </div>
+
+            <Link
+              to="/"
+              className={`${brandLinkClass} max-[500px]:hidden`}
+              onClick={handleClosePanels}
+            >
+              <span className="relative inline-block">
+                <span className={brandTextBaseClass}>Telegro</span>
+                <span aria-hidden="true" className={brandTextGradientClass}>
+                  Telegro
+                </span>
+              </span>
+            </Link>
+
+            <Link
+              to="/products"
+              className={`${linkClass} max-[500px]:hidden`}
+              onClick={handleClosePanels}
+            >
+              상품
+            </Link>
+            <Link
+              to="/notices"
+              className={`${linkClass} max-[500px]:hidden`}
+              onClick={handleClosePanels}
+            >
+              공지사항
+            </Link>
+            <Link
+              to="/app/cart"
+              className={`${linkClass} max-[500px]:hidden`}
+              onClick={handleClosePanels}
+            >
+              장바구니
+            </Link>
+
+            <div className="ml-auto flex items-center gap-6 max-[500px]:hidden">
+              {isLoggedIn ? (
+                <>
+                  <button
+                    type="button"
+                    aria-label="알림 보기"
+                    aria-expanded={isNotificationOpen}
+                    aria-controls="notification-drawer"
+                    onClick={() => setIsNotificationOpen(true)}
+                    className="place-items-center rounded-full px-2 py-1 transition-colors hover:bg-black/5"
+                  >
+                    {notificationButton}
+                  </button>
+                  <Link
+                    to="/app/my"
+                    className={linkClass}
+                    onClick={handleClosePanels}
+                  >
+                    마이페이지
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <Link
+                    to="/guest/orders"
+                    className={secondaryLinkClass}
+                    onClick={handleClosePanels}
+                  >
+                    비회원 주문조회
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => setIsLoginOverlayOpen(true)}
+                    className={linkClass}
+                  >
+                    로그인하기
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+
+          <div
+            id="public-mobile-menu"
+            className={`hidden overflow-hidden transition-all duration-300 ease-out max-[500px]:mt-[1.2rem] max-[500px]:block ${
+              isMobileMenuOpen ? 'max-[500px]:max-h-[40rem]' : 'max-[500px]:max-h-0'
+            }`}
+          >
+            <div className="flex flex-col gap-[0.8rem] border-t border-[#f0f0f0] pt-[1.2rem]">
+              <Link
+                to="/products"
+                className={`${linkClass} rounded-[1rem] px-[0.6rem] py-[0.8rem]`}
+                onClick={handleClosePanels}
+              >
+                상품
+              </Link>
+              <Link
+                to="/notices"
+                className={`${linkClass} rounded-[1rem] px-[0.6rem] py-[0.8rem]`}
+                onClick={handleClosePanels}
+              >
+                공지사항
+              </Link>
+              <Link
+                to="/app/cart"
+                className={`${linkClass} rounded-[1rem] px-[0.6rem] py-[0.8rem]`}
+                onClick={handleClosePanels}
+              >
+                장바구니
+              </Link>
+
+              {isLoggedIn ? (
+                <>
+                  <button
+                    type="button"
+                    aria-label="알림 보기"
+                    aria-expanded={isNotificationOpen}
+                    aria-controls="notification-drawer"
+                    onClick={() => {
+                      setIsNotificationOpen(true);
+                      setIsMobileMenuOpen(false);
+                    }}
+                    className={`${linkClass} rounded-[1rem] px-[0.6rem] py-[0.8rem] text-left`}
+                  >
+                    알림
+                  </button>
+                  <Link
+                    to="/app/my"
+                    className={`${linkClass} rounded-[1rem] px-[0.6rem] py-[0.8rem]`}
+                    onClick={handleClosePanels}
+                  >
+                    마이페이지
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <Link
+                    to="/guest/orders"
+                    className={`${secondaryLinkClass} rounded-[1rem] px-[0.6rem] py-[0.8rem]`}
+                    onClick={handleClosePanels}
+                  >
+                    비회원 주문조회
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsLoginOverlayOpen(true);
+                      setIsMobileMenuOpen(false);
+                    }}
+                    className={`${linkClass} rounded-[1rem] px-[0.6rem] py-[0.8rem] text-left`}
+                  >
+                    로그인하기
+                  </button>
+                </>
+              )}
+            </div>
           </div>
         </nav>
       </header>


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #55

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 설명

500px 이하인 환경에서 나타나는 모바일 헤더를 구현했습니다.

## 🚀 해결한 TODO

- [x] 모바일 헤더 UI 구현 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive mobile navigation menu to admin and public layouts with collapsible menu controls.
  * Mobile menu automatically closes when navigating between pages.
  * Improved mobile header layout with adapted notification and login controls.
  * Increased recent orders displayed from 4 to 5 items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->