### PR TITLE
[Feat/#54] 주문 목록 엑셀 다운로드 기능 추가 (All)

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -16,8 +16,8 @@
     />
     <title>Telegro</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script type="module" crossorigin src="/assets/index-a7QlTjXh.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DPqohPRt.css">
+    <script type="module" crossorigin src="/assets/index-CBsPBzXT.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-B7VFErht.css">
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-router-dom": "^7.8.0",
     "tailwind-merge": "^3.3.1",
     "tui-color-picker": "^2.2.8",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.2)(vite@7.1.2(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.21.0)(yaml@2.8.1))
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.8.1
@@ -1156,6 +1159,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
@@ -1329,6 +1336,10 @@ packages:
   caniuse-lite@1.0.30001734:
     resolution: {integrity: sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chalk@1.1.3:
     resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
     engines: {node: '>=0.10.0'}
@@ -1364,6 +1375,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   collection-visit@1.0.0:
     resolution: {integrity: sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==}
@@ -1440,6 +1455,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1813,6 +1833,10 @@ packages:
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fragment-cache@0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -3142,6 +3166,10 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stable@0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
     deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
@@ -3492,13 +3520,26 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -4629,6 +4670,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  adler-32@1.3.1: {}
+
   ajv-draft-04@1.0.0(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
@@ -4808,6 +4851,11 @@ snapshots:
 
   caniuse-lite@1.0.30001734: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chalk@1.1.3:
     dependencies:
       ansi-styles: 2.2.1
@@ -4845,6 +4893,8 @@ snapshots:
   clone@2.1.2: {}
 
   clsx@2.1.1: {}
+
+  codepage@1.15.0: {}
 
   collection-visit@1.0.0:
     dependencies:
@@ -4915,6 +4965,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.2
+
+  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5434,6 +5486,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  frac@1.1.2: {}
 
   fragment-cache@0.2.1:
     dependencies:
@@ -6718,6 +6772,10 @@ snapshots:
 
   split2@4.2.0: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stable@0.1.8: {}
 
   static-extend@0.1.2:
@@ -7117,13 +7175,27 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   y18n@5.0.8: {}
 

--- a/src/pages/admin/orders/orders.tsx
+++ b/src/pages/admin/orders/orders.tsx
@@ -2,6 +2,7 @@ import AdminProfileCard from '@components/admin/profile-card/profile-card';
 import ExploreScrollToTop from '@components/common/explore-scroll-to-top';
 import LoadingPanel from '@components/common/loading-panel';
 import SearchBar from '@components/common/search-bar';
+import OrderExportButton from '@components/order/order-export-button';
 import OrderListTable from '@components/order/order-list-table';
 import { useInfiniteScrollTrigger } from '@hooks/use-infinite-scroll-trigger';
 import useOrderList, { type OrderFilterType } from '@hooks/use-order-list';
@@ -23,8 +24,10 @@ const AdminOrders = () => {
   const [appliedFilterBy, setAppliedFilterBy] = useState<OrderFilterType>();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const filterRef = useRef<HTMLDivElement>(null);
+
   const {
     orders,
+    sourceOrders,
     isLoading,
     isError,
     hasNextPage,
@@ -80,14 +83,20 @@ const AdminOrders = () => {
   return (
     <div
       ref={pageRef}
-      className="flex-col gap-[5rem] bg-[#FAFAFA] px-[2rem] py-[2rem] md:px-[5rem] md:py-[3rem] lg:px-[10rem] lg:py-[5rem]"
+      className="flex flex-col gap-[5rem] bg-[#FAFAFA] px-[2rem] py-[2rem] md:px-[5rem] md:py-[3rem] lg:px-[10rem] lg:py-[5rem]"
     >
       <AdminProfileCard onMove={() => navigate('/')} />
 
       <div className="flex flex-col gap-[3.5rem]">
-        <h1 className="title3 text-gray-900">주문 목록</h1>
+        <div className="flex-row-between w-full">
+          <h1 className="title3 text-gray-900">주문 목록</h1>
 
-        <div ref={filterRef} className="relative">
+          <OrderExportButton
+            orders={sourceOrders}
+            isFiltered={Boolean(appliedSearchKeyword.trim())}
+          />
+        </div>
+        <div ref={filterRef} className="relative flex-1">
           <SearchBar
             value={keyword}
             onChange={setKeyword}
@@ -134,10 +143,13 @@ const AdminOrders = () => {
       ) : orders.length ? (
         <div className="flex flex-col gap-4">
           <OrderListTable data={orders} detailBasePath="/admin/orders" />
-          {(hasNextPage || isFetchingNextPage) ? (
+          {hasNextPage || isFetchingNextPage ? (
             <div ref={loadMoreRef}>
               {isFetchingNextPage ? (
-                <LoadingPanel className="min-h-0 rounded-[1.6rem] py-[2rem]" size={72} />
+                <LoadingPanel
+                  className="min-h-0 rounded-[1.6rem] py-[2rem]"
+                  size={72}
+                />
               ) : (
                 <div className="h-[1px] w-full" />
               )}

--- a/src/pages/app/orders/orders.tsx
+++ b/src/pages/app/orders/orders.tsx
@@ -1,6 +1,7 @@
 import ExploreScrollToTop from '@components/common/explore-scroll-to-top';
 import LoadingPanel from '@components/common/loading-panel';
 import SearchBar from '@components/common/search-bar';
+import OrderExportButton from '@components/order/order-export-button';
 import OrderListTable from '@components/order/order-list-table';
 import { useInfiniteScrollTrigger } from '@hooks/use-infinite-scroll-trigger';
 import useOrderList, { type OrderFilterType } from '@hooks/use-order-list';
@@ -20,8 +21,10 @@ const Orders = () => {
   const [appliedFilterBy, setAppliedFilterBy] = useState<OrderFilterType>();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const filterRef = useRef<HTMLDivElement>(null);
+
   const {
     orders,
+    sourceOrders,
     isLoading,
     isError,
     hasNextPage,
@@ -80,9 +83,16 @@ const Orders = () => {
       className="flex flex-col gap-[5rem] bg-[#FAFAFA] px-[2rem] py-[2rem] md:px-[5rem] md:py-[3rem] lg:px-[10rem] lg:py-[5rem]"
     >
       <div className="flex flex-col gap-[3.5rem]">
-        <h1 className="title3 text-gray-900">주문 목록</h1>
+        <div className="flex-row-between w-full">
+          <h1 className="title3 text-gray-900">주문 목록</h1>
 
-        <div ref={filterRef} className="relative">
+          <OrderExportButton
+            orders={sourceOrders}
+            isFiltered={Boolean(appliedSearchKeyword.trim())}
+          />
+        </div>
+
+        <div ref={filterRef} className="relative flex-1">
           <SearchBar
             value={keyword}
             onChange={setKeyword}
@@ -129,10 +139,13 @@ const Orders = () => {
       ) : orders.length ? (
         <div className="flex flex-col gap-4">
           <OrderListTable data={orders} />
-          {(hasNextPage || isFetchingNextPage) ? (
+          {hasNextPage || isFetchingNextPage ? (
             <div ref={loadMoreRef}>
               {isFetchingNextPage ? (
-                <LoadingPanel className="min-h-0 rounded-[1.6rem] py-[2rem]" size={72} />
+                <LoadingPanel
+                  className="min-h-0 rounded-[1.6rem] py-[2rem]"
+                  size={72}
+                />
               ) : (
                 <div className="h-[1px] w-full" />
               )}

--- a/src/shared/components/common/global-site-toast.tsx
+++ b/src/shared/components/common/global-site-toast.tsx
@@ -17,7 +17,7 @@ const GlobalSiteToast = () => {
         </div>
 
         <p className="w-[35rem] max-w-[calc(100vw-12rem)] text-[14px] leading-[21px] font-medium break-words whitespace-pre-line text-white">
-          텔레그로 사이트 방문해주셔서 감사합니다. {'\n'}
+          텔레그로 사이트에 방문해주셔서 감사합니다. {'\n'}
           제품에 대한 문의 주시면 자세하게 설명 드리겠습니다. {'\n'}
           제품출고마감 : 당일 오후 3시 접수마감 입니다.
         </p>

--- a/src/shared/components/order/order-export-button.tsx
+++ b/src/shared/components/order/order-export-button.tsx
@@ -10,20 +10,20 @@ type OrderExportButtonProps = {
 };
 
 type ExcelRow = {
-  no: number;
-  orderNumber: number | string;
-  recipientName: string;
-  phoneNumber: string;
-  address: string;
-  addressDetailAndZipcode: string;
-  productName: string;
-  quantity: number;
-  option: string;
-  unitPrice: string;
-  totalPrice: string;
-  orderStatus: string;
-  orderDate: string;
-  request: string;
+  No: number;
+  주문번호: number | string;
+  수령인명: string;
+  전화번호: string;
+  주소: string;
+  상세주소_우편번호: string;
+  상품명: string;
+  수량: number;
+  옵션: string;
+  상품단가: string;
+  총금액: string;
+  주문상태: string;
+  주문일자: string;
+  요청사항: string;
 };
 
 const getOptionLabel = (
@@ -42,22 +42,22 @@ const getWorksheetData = (orders: OrderDetailDTO[]): ExcelRow[] =>
         (
           product: NonNullable<OrderDetailDTO['products']>[number],
         ): ExcelRow => ({
-          no: index + 1,
-          orderNumber: order.orderId ?? '-',
-          recipientName: order.deliveryAddress?.recipientName?.trim() || 'N/A',
-          phoneNumber: order.deliveryAddress?.phoneNumber?.trim() || 'N/A',
-          address: order.deliveryAddress?.address?.trim() || 'N/A',
-          addressDetailAndZipcode: `${
+          No: index + 1,
+          주문번호: order.orderId ?? '-',
+          수령인명: order.deliveryAddress?.recipientName?.trim() || 'N/A',
+          전화번호: order.deliveryAddress?.phoneNumber?.trim() || 'N/A',
+          주소: order.deliveryAddress?.address?.trim() || 'N/A',
+          상세주소_우편번호: `${
             order.deliveryAddress?.addressDetail?.trim() || 'N/A'
           } / ${order.deliveryAddress?.zipcode?.trim() || 'N/A'}`,
-          productName: product.productName?.trim() || 'N/A',
-          quantity: product.quantity ?? 0,
-          option: getOptionLabel(product),
-          unitPrice: `${formatNumber(product.productPrice ?? 0)} KRW`,
-          totalPrice: `${formatNumber(product.totalPrice ?? 0)} KRW`,
-          orderStatus: order.orderStatus || '-',
-          orderDate: formatDate(order.createdAt),
-          request: order.request?.trim() || '-',
+          상품명: product.productName?.trim() || 'N/A',
+          수량: product.quantity ?? 0,
+          옵션: getOptionLabel(product),
+          상품단가: `${formatNumber(product.productPrice ?? 0)} KRW`,
+          총금액: `${formatNumber(product.totalPrice ?? 0)} KRW`,
+          주문상태: order.orderStatus || '-',
+          주문일자: formatDate(order.createdAt),
+          요청사항: order.request?.trim() || '-',
         }),
       );
 

--- a/src/shared/components/order/order-export-button.tsx
+++ b/src/shared/components/order/order-export-button.tsx
@@ -107,7 +107,7 @@ const OrderExportButton = ({
       type="button"
       onClick={handleExport}
       disabled={isExporting}
-      className="inline-flex h-[5.3rem] shrink-0 cursor-pointer items-center justify-center gap-3 rounded-[12px] bg-[#171717] px-8 text-[1.6rem] font-medium text-white transition hover:bg-[#2B2B2B] disabled:cursor-not-allowed disabled:bg-[#8C8C8C]"
+      className="inline-flex shrink-0 cursor-pointer items-center justify-center gap-3 rounded-[10px] bg-green-600 px-8 py-4 text-[1.5rem] font-medium text-white transition hover:bg-[#2B2B2B] disabled:cursor-not-allowed disabled:bg-[#8C8C8C]"
     >
       <FiDownload className="h-5 w-5" />
       {isExporting ? 'Exporting...' : 'Excel Download'}

--- a/src/shared/components/order/order-export-button.tsx
+++ b/src/shared/components/order/order-export-button.tsx
@@ -1,0 +1,118 @@
+import type { OrderDetailDTO } from '@apis/telegro';
+import { toastError } from '@components/common/toast/toast';
+import { formatDate, formatNumber } from '@utils/format';
+import { useState } from 'react';
+import { FiDownload } from 'react-icons/fi';
+
+type OrderExportButtonProps = {
+  orders: OrderDetailDTO[];
+  isFiltered?: boolean;
+};
+
+type ExcelRow = {
+  no: number;
+  orderNumber: number | string;
+  recipientName: string;
+  phoneNumber: string;
+  address: string;
+  addressDetailAndZipcode: string;
+  productName: string;
+  quantity: number;
+  option: string;
+  unitPrice: string;
+  totalPrice: string;
+  orderStatus: string;
+  orderDate: string;
+  request: string;
+};
+
+const getOptionLabel = (
+  product: NonNullable<OrderDetailDTO['products']>[number],
+) =>
+  [product.selectOption, product.inputOption, product.productModel]
+    .filter(Boolean)
+    .join(' / ') || 'N/A';
+
+const getWorksheetData = (orders: OrderDetailDTO[]): ExcelRow[] =>
+  orders.reduce<ExcelRow[]>(
+    (rows: ExcelRow[], order: OrderDetailDTO, index: number) => {
+      const products = order.products ?? [];
+
+      const nextRows = products.map(
+        (
+          product: NonNullable<OrderDetailDTO['products']>[number],
+        ): ExcelRow => ({
+          no: index + 1,
+          orderNumber: order.orderId ?? '-',
+          recipientName: order.deliveryAddress?.recipientName?.trim() || 'N/A',
+          phoneNumber: order.deliveryAddress?.phoneNumber?.trim() || 'N/A',
+          address: order.deliveryAddress?.address?.trim() || 'N/A',
+          addressDetailAndZipcode: `${
+            order.deliveryAddress?.addressDetail?.trim() || 'N/A'
+          } / ${order.deliveryAddress?.zipcode?.trim() || 'N/A'}`,
+          productName: product.productName?.trim() || 'N/A',
+          quantity: product.quantity ?? 0,
+          option: getOptionLabel(product),
+          unitPrice: `${formatNumber(product.productPrice ?? 0)} KRW`,
+          totalPrice: `${formatNumber(product.totalPrice ?? 0)} KRW`,
+          orderStatus: order.orderStatus || '-',
+          orderDate: formatDate(order.createdAt),
+          request: order.request?.trim() || '-',
+        }),
+      );
+
+      return [...rows, ...nextRows];
+    },
+    [],
+  );
+
+const getExportDate = () => new Date().toISOString().slice(0, 10);
+
+const OrderExportButton = ({
+  orders,
+  isFiltered = false,
+}: OrderExportButtonProps) => {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = async () => {
+    if (!orders.length) {
+      toastError('No data to export.');
+      return;
+    }
+
+    const excelData = getWorksheetData(orders);
+    if (!excelData.length) {
+      toastError('No data to export.');
+      return;
+    }
+
+    setIsExporting(true);
+
+    try {
+      const XLSX = await import('xlsx');
+      const worksheet = XLSX.utils.json_to_sheet(excelData);
+      const workbook = XLSX.utils.book_new();
+      const sheetName = isFiltered ? 'filtered_orders' : 'all_orders';
+      const fileName = `${sheetName}_${getExportDate()}.xlsx`;
+
+      XLSX.utils.book_append_sheet(workbook, worksheet, sheetName);
+      XLSX.writeFile(workbook, fileName);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleExport}
+      disabled={isExporting}
+      className="inline-flex h-[5.3rem] shrink-0 cursor-pointer items-center justify-center gap-3 rounded-[12px] bg-[#171717] px-8 text-[1.6rem] font-medium text-white transition hover:bg-[#2B2B2B] disabled:cursor-not-allowed disabled:bg-[#8C8C8C]"
+    >
+      <FiDownload className="h-5 w-5" />
+      {isExporting ? 'Exporting...' : 'Excel Download'}
+    </button>
+  );
+};
+
+export default OrderExportButton;

--- a/src/shared/hooks/use-order-list.ts
+++ b/src/shared/hooks/use-order-list.ts
@@ -134,12 +134,32 @@ export const useOrderList = ({
     },
   );
 
+  const sourceOrders = useMemo<OrderDetailDTO[]>(
+    () => {
+      const mergedOrders = (orderQuery.data?.pages ?? []).reduce<OrderDetailDTO[]>(
+        (acc, page) => [...acc, ...getPageOrders(page)],
+        [],
+      );
+
+      return mergedOrders.reduce<OrderDetailDTO[]>((acc, order) => {
+        if (
+          order.orderId != null &&
+          acc.some((currentOrder) => currentOrder.orderId === order.orderId)
+        ) {
+          return acc;
+        }
+
+        return [...acc, order];
+      }, []);
+    },
+    [orderQuery.data?.pages],
+  );
+
   const orders = useMemo<OrderRow[]>(
     () => {
-      const rows = (orderQuery.data?.pages ?? []).reduce<OrderRow[]>((acc, page, pageIndex) => {
-        const rows = getPageOrders(page).map((order, index) => ({
-          id: order.orderId ?? pageIndex * pageSize + index + 1,
-          orderId: order.orderId ?? pageIndex * pageSize + index + 1,
+      return sourceOrders.map((order, index) => ({
+        id: order.orderId ?? index + 1,
+        orderId: order.orderId ?? index + 1,
           productName: formatProductName(order),
           optionLabel: formatOptionLabel(order),
           quantity: getQuantity(order),
@@ -154,21 +174,10 @@ export const useOrderList = ({
           orderInfo: getOrderInfo(order),
           customerInfo: getCustomerInfo(order),
           statusLabel: getOrderStatusLabel(order.orderStatus),
-          statusValue: getStatusValue(order),
-        }));
-
-        return [...acc, ...rows];
-      }, []);
-
-      return rows.reduce<OrderRow[]>((acc, row) => {
-        if (acc.some((currentRow) => currentRow.orderId === row.orderId)) {
-          return acc;
-        }
-
-        return [...acc, row];
-      }, []);
+        statusValue: getStatusValue(order),
+      }));
     },
-    [orderQuery.data?.pages, pageSize],
+    [sourceOrders],
   );
 
   const pages = orderQuery.data?.pages ?? [];
@@ -180,6 +189,7 @@ export const useOrderList = ({
 
   return {
     orders,
+    sourceOrders,
     totalCount,
     isLoading: orderQuery.isLoading,
     isError: orderQuery.isError,


### PR DESCRIPTION
            
  Closes #54                                                                                                                          
                                                                                                                                      
  <!-- 해당 PR에 대한 설명을 작성해 주세요. !-->                                                                                      
                                                                                                                                      
  ## 🔎 설명                                                                                                                          
                                                                                                                                      
  주문 목록 페이지에 엑셀 다운로드 기능을 추가했습니다.                                                                               
  일반 주문 목록과 관리자 주문 목록에서 현재 조회 중인 주문 데이터를 엑셀 파일로 내려받을 수 있으며, 엑셀 컬럼 헤더는 한국어로 표기되도록 구성했습니다.                                                                                                                  
                                                                                                                                      
  ## 🚀 해결한 TODO                                                                                                                   
                                                                                                                                      
  - [x] 주문 목록에서 엑셀 다운로드 버튼 추가                                                                                         
  - [x] 엑셀 다운로드용 주문 원본 데이터 반환 구조 추가                                                                               
  - [x] `xlsx` 의존성 추가 및 다운로드 데이터 헤더 한국어화                                                                           
                                                                                                                                      
  ##  상세 설명💎                                                                                                                     
                                                                                                                                      
  - `OrderExportButton` 공통 컴포넌트를 추가해 주문 데이터를 엑셀로 내보낼 수 있도록 구현했습니다.                                    
  - `useOrderList` 훅에서 화면 표시용 row 데이터와 별도로 엑셀 생성에 필요한 원본 주문 데이터(`sourceOrders`)를 함께 반환하도록 확장했
  습니다.                                                                                                                             
  - 사용자 주문 목록(`/app/orders`)과 관리자 주문 목록(`/admin/orders`) 상단에 엑셀 다운로드 버튼을 추가했습니다.                     
  - 엑셀 헤더를 아래와 같이 한국어로 정리했습니다.                                                                                    
    - `주문번호`, `수령인명`, `전화번호`, `주소`, `상세주소_우편번호`, `상품명`, `수량`, `옵션`, `상품단가`, `총금액`, `주문상태`, `주
  문일자`, `요청사항`                                                                                                                 
  - `xlsx` 패키지를 추가하고 lockfile을 갱신했습니다.                                                                                 
  - 함께 포함된 변경으로 글로벌 사이트 토스트 문구를 자연스럽게 수정했습니다.                                                         
                                                                                                                                      
  ## 💎 새롭게 알게 된 / 공부한 내용                                                                                                  
                                                                                                                                      
  - 현재 프로젝트의 `tsconfig` 타깃이 `ES2017`이라 `flatMap` 사용 시 타입 에러가 발생할 수 있어 `reduce` 기반으로 구현하는 편이 안전했습니다.                                                                                                                             
  - 엑셀 컬럼명은 `json_to_sheet`에 전달하는 객체의 key 값이 그대로 헤더가 되므로, 다운로드 헤더 한글화는 row key 변경만으로 처리할 수 있었습니다.                                                                                                                         
  - 주문 목록 화면의 표시용 데이터와 다운로드용 원본 데이터 요구사항이 달라, 훅 레벨에서 두 형태를 함께 제공하는 구조가 재사용성과 유지보수에 유리했습니다.                                                                                                              
                                                                                                                                      
  <!-- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->                                          
                                                                                                                                      
  ## 📷 Screenshots or Video                                                                                                          
                                                                                                                                      
  화면 구조 변경은 크지 않고, 주요 변경은 파일 다운로드 기능이라 별도 스크린샷은 첨부하지 않았습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added order export functionality to admin and customer order pages, enabling users to download orders as Excel files with support for filtered and complete datasets.

* **Improvements**
  * Updated Korean notification message text for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->