### PR TITLE
[Feat/#59] 주문 취소 API 수정 (All)

### DIFF
--- a/src/shared/components/order/order-detail-view.tsx
+++ b/src/shared/components/order/order-detail-view.tsx
@@ -87,13 +87,12 @@ function StepIndicator({
 }: {
   currentStatus?: OrderDetailResponseDTOOrderStatus;
 }) {
-  const activeIndex = getStepIndex(currentStatus);
   const isCancelled = currentStatus === 'ORDER_CANCELLED';
 
-  return (
-    <div className="overflow-hidden rounded-[1.8rem] border border-neutral-200 bg-white">
-      {isCancelled ? (
-        <div className="flex items-center gap-4 border-b border-neutral-200 bg-[#171717] px-6 py-5 text-white">
+  if (isCancelled) {
+    return (
+      <div className="overflow-hidden rounded-[1.8rem] border border-neutral-200 bg-white">
+        <div className="flex items-center gap-4 bg-[#171717] px-6 py-5 text-white">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10">
             <FiClock className="text-lg" />
           </div>
@@ -104,8 +103,14 @@ function StepIndicator({
             </p>
           </div>
         </div>
-      ) : null}
+      </div>
+    );
+  }
 
+  const activeIndex = getStepIndex(currentStatus);
+
+  return (
+    <div className="overflow-hidden rounded-[1.8rem] border border-neutral-200 bg-white">
       <div className="grid gap-px bg-neutral-200 md:grid-cols-5">
         {orderSteps.map((step, index) => {
           const isActive = index === activeIndex;

--- a/src/shared/components/order/order-list-table.tsx
+++ b/src/shared/components/order/order-list-table.tsx
@@ -1,5 +1,6 @@
-import { useUpdateOrderStatus } from '@apis/telegro';
+import { useCancelPayment, useUpdateOrderStatus } from '@apis/telegro';
 import Icon from '@components/common/icon';
+import { toastSuccess } from '@components/common/toast/toast';
 import {
   ORDER_STATUS_OPTIONS,
   type OrderStatusCode,
@@ -71,11 +72,20 @@ const OrderStatusControl = ({ row }: { row: OrderRow }) => {
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const handleMutationSuccess = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['/api/orders'] });
+    setIsOpen(false);
+  };
   const updateOrderStatus = useUpdateOrderStatus({
     mutation: {
+      onSuccess: handleMutationSuccess,
+    },
+  });
+  const cancelPayment = useCancelPayment({
+    mutation: {
       onSuccess: async () => {
-        await queryClient.invalidateQueries({ queryKey: ['/api/orders'] });
-        setIsOpen(false);
+        await handleMutationSuccess();
+        toastSuccess('취소되었습니다.');
       },
     },
   });
@@ -83,6 +93,7 @@ const OrderStatusControl = ({ row }: { row: OrderRow }) => {
   useOutsideClose(isOpen, containerRef, () => setIsOpen(false));
 
   const isCancelled = row.statusValue === 'ORDER_CANCELLED';
+  const isMutating = updateOrderStatus.isPending || cancelPayment.isPending;
   const availableOptions =
     row.statusValue === 'ORDER_CREATED'
       ? STATUS_OPTIONS.filter((option) => option.value === 'ORDER_CANCELLED')
@@ -104,7 +115,7 @@ const OrderStatusControl = ({ row }: { row: OrderRow }) => {
     >
       <button
         type="button"
-        disabled={updateOrderStatus.isPending}
+        disabled={isMutating}
         onClick={() => setIsOpen((prev) => !prev)}
         className="inline-flex h-[4.4rem] w-full max-w-[10.5rem] items-center justify-center gap-2 rounded-[12px] bg-[#F5F5F5] px-3 text-[1.3rem] font-medium text-[#2B2B2B] transition hover:bg-[#EBEBEB] disabled:cursor-not-allowed disabled:opacity-60 md:text-[1.5rem]"
       >
@@ -118,10 +129,13 @@ const OrderStatusControl = ({ row }: { row: OrderRow }) => {
             <button
               key={option.value}
               type="button"
-              disabled={
-                option.value === row.statusValue || updateOrderStatus.isPending
-              }
+              disabled={option.value === row.statusValue || isMutating}
               onClick={() => {
+                if (option.value === 'ORDER_CANCELLED') {
+                  cancelPayment.mutate({ orderId: row.orderId });
+                  return;
+                }
+
                 updateOrderStatus.mutate({
                   orderId: row.orderId,
                   params: { status: option.value },


### PR DESCRIPTION
                                                                                     
  Closes #59                                                                                                                          
                                                                                                                                      
  ## 작업 설명                                                                                                                        
                                                                                                                                      
  관리자 주문 상태 변경에서 `ORDER_CANCELLED`를 일반 주문 상태 변경 API가 아니라 결제 취소 전용 API(`/api/payments/cancel/{orderId}`)로 호출하도록 수정했습니다.                                                                                                         
추가로 주문 취소 성공 시 사용자 피드백을 위해 토스트를 노출하고, 주문 상세 화면에서 취소 상태일 경우 진행 인디케이터 대신 취소 상태만 표시하도록 UI를 정리했습니다.                                                                                                    
                                                                                                                                      
  ## 작업 해결한 TODO                                                                                                                 
                                                                                                                                      
  - [x] 주문 취소 시 전용 결제 취소 API 호출로 분기                                                                                   
  - [x] 주문 취소 성공 토스트 추가                                                                                                    
  - [x] 주문 상세에서 취소 상태 UI 개선                                                                                               
                                                                                                                                      
  ## 상세 설명, 작업 내용                                                                                                             
                                                                                                                                      
  `src/shared/components/order/order-list-table.tsx`                                                                                  
  - 관리자 주문 목록의 상태 드롭다운에서 `ORDER_CANCELLED` 선택 시 `useCancelPayment` mutation을 호출하도록 변경                      
  - 일반 상태 변경은 기존 `useUpdateOrderStatus`를 유지                                                                               
  - 취소 성공 시 `취소되었습니다.` 성공 토스트 노출                                                                                   
  - 상태 변경/취소 요청 중에는 공통 pending 상태로 버튼 비활성화 처리                                                                 
  - 성공 후 주문 목록 캐시 invalidate 및 드롭다운 닫기 공통화                                                                         
                                                                                                                                      
  `src/shared/components/order/order-detail-view.tsx`                                                                                 
  - 주문 상세 상단 상태 인디케이터에서 `ORDER_CANCELLED`인 경우 단계형 진행 UI를 렌더링하지 않도록 수정                               
  - 취소 상태 전용 카드만 표시되도록 분기 처리                                                                                        
                               
                                                                                                                                      
  ## Screenshots or Video                                                                                                             
                                                                                                                                      
  없음   