### PR TITLE
[Feat/#62] 엑셀 다운로드 시 현재 필터 조건으로 전체 주문 조회 적용 (All)

### DIFF
--- a/src/pages/admin/orders/orders.tsx
+++ b/src/pages/admin/orders/orders.tsx
@@ -35,7 +35,6 @@ const AdminOrders = () => {
 
   const {
     orders,
-    sourceOrders,
     isLoading,
     isError,
     hasNextPage,
@@ -127,9 +126,19 @@ const AdminOrders = () => {
           </div>
 
           <OrderExportButton
-            orders={sourceOrders}
+            filters={{
+              filterBy: appliedFilterBy,
+              q: appliedSearchKeyword.trim() || undefined,
+              startDate: startDate || undefined,
+              endDate: endDate || undefined,
+              orderStatus:
+                selectedStatus !== 'ALL' ? selectedStatus : undefined,
+            }}
             isFiltered={Boolean(
-              appliedSearchKeyword.trim() || startDate || endDate,
+              appliedSearchKeyword.trim() ||
+                startDate ||
+                endDate ||
+                selectedStatus !== 'ALL',
             )}
           />
         </div>

--- a/src/pages/app/orders/orders.tsx
+++ b/src/pages/app/orders/orders.tsx
@@ -32,7 +32,6 @@ const Orders = () => {
 
   const {
     orders,
-    sourceOrders,
     isLoading,
     isError,
     hasNextPage,
@@ -122,9 +121,19 @@ const Orders = () => {
           </div>
 
           <OrderExportButton
-            orders={sourceOrders}
+            filters={{
+              filterBy: appliedFilterBy,
+              q: appliedSearchKeyword.trim() || undefined,
+              startDate: startDate || undefined,
+              endDate: endDate || undefined,
+              orderStatus:
+                selectedStatus !== 'ALL' ? selectedStatus : undefined,
+            }}
             isFiltered={Boolean(
-              appliedSearchKeyword.trim() || startDate || endDate,
+              appliedSearchKeyword.trim() ||
+                startDate ||
+                endDate ||
+                selectedStatus !== 'ALL',
             )}
           />
         </div>

--- a/src/shared/apis/telegro/cursor.ts
+++ b/src/shared/apis/telegro/cursor.ts
@@ -82,6 +82,14 @@ type OrderCursorParams = Omit<GetOrdersParams, 'page'> & {
   orderStatus?: string;
 };
 
+export type OrderListFilters = {
+  filterBy?: string;
+  q?: string;
+  startDate?: string;
+  endDate?: string;
+  orderStatus?: string;
+};
+
 type CartCursorParams = {
   size: number;
   cursor?: CursorValue;
@@ -388,6 +396,27 @@ export const getCursorOrders = (
         },
         params.cursor,
       ),
+      signal,
+    },
+    options,
+  );
+
+export const getAllOrders = (
+  params: OrderListFilters,
+  options?: AxiosRequestConfig,
+  signal?: AbortSignal,
+) =>
+  axiosInstance<SuccessResponseOrderListDTO>(
+    {
+      url: '/api/orders/all',
+      method: 'GET',
+      params: {
+        filterBy: params.filterBy,
+        q: params.q,
+        startDate: params.startDate,
+        endDate: params.endDate,
+        orderStatus: params.orderStatus,
+      },
       signal,
     },
     options,

--- a/src/shared/components/order/order-export-button.tsx
+++ b/src/shared/components/order/order-export-button.tsx
@@ -1,11 +1,15 @@
-import type { OrderDetailDTO } from '@apis/telegro';
+import {
+  getAllOrders,
+  type OrderDetailDTO,
+  type OrderListFilters,
+} from '@apis/telegro';
 import { toastError } from '@components/common/toast/toast';
 import { formatDate, formatNumber } from '@utils/format';
 import { useState } from 'react';
 import { FiDownload } from 'react-icons/fi';
 
 type OrderExportButtonProps = {
-  orders: OrderDetailDTO[];
+  filters: OrderListFilters;
   isFiltered?: boolean;
 };
 
@@ -68,27 +72,48 @@ const getWorksheetData = (orders: OrderDetailDTO[]): ExcelRow[] =>
 
 const getExportDate = () => new Date().toISOString().slice(0, 10);
 
+const getOrdersFromResponse = (
+  ordersResponse: Awaited<ReturnType<typeof getAllOrders>>,
+) => {
+  const data = ordersResponse.data;
+
+  if (Array.isArray(data?.orders)) {
+    return data.orders;
+  }
+
+  if (
+    Array.isArray((data as { content?: OrderDetailDTO[] } | undefined)?.content)
+  ) {
+    return (data as { content: OrderDetailDTO[] }).content;
+  }
+
+  return [];
+};
+
 const OrderExportButton = ({
-  orders,
+  filters,
   isFiltered = false,
 }: OrderExportButtonProps) => {
   const [isExporting, setIsExporting] = useState(false);
 
   const handleExport = async () => {
-    if (!orders.length) {
-      toastError('No data to export.');
-      return;
-    }
-
-    const excelData = getWorksheetData(orders);
-    if (!excelData.length) {
-      toastError('No data to export.');
-      return;
-    }
-
     setIsExporting(true);
 
     try {
+      const ordersResponse = await getAllOrders(filters);
+      const orders = getOrdersFromResponse(ordersResponse);
+
+      if (!orders.length) {
+        toastError('No data to export.');
+        return;
+      }
+
+      const excelData = getWorksheetData(orders);
+      if (!excelData.length) {
+        toastError('No data to export.');
+        return;
+      }
+
       const XLSX = await import('xlsx');
       const worksheet = XLSX.utils.json_to_sheet(excelData);
       const workbook = XLSX.utils.book_new();
@@ -97,6 +122,8 @@ const OrderExportButton = ({
 
       XLSX.utils.book_append_sheet(workbook, worksheet, sheetName);
       XLSX.writeFile(workbook, fileName);
+    } catch {
+      toastError('Failed to export orders.');
     } finally {
       setIsExporting(false);
     }

--- a/src/shared/layouts/admin-layout.tsx
+++ b/src/shared/layouts/admin-layout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { FiMenu, FiX } from 'react-icons/fi';
-import { Outlet, Link, useLocation } from 'react-router-dom';
+import { Link, Outlet, useLocation } from 'react-router-dom';
 
 const linkClass =
   'title6 text-gray-900 no-underline transition-underline hover:underline';
@@ -23,7 +23,7 @@ const AdminLayout = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="flex min-h-screen flex-col bg-white">
       <header className="fixed top-0 z-50 w-full border-b border-[#eee] bg-white px-[3rem] py-[1.6rem] max-[535px]:px-[1.6rem] max-[535px]:pt-[1.2rem] max-[535px]:pb-0">
         <nav className="px-[3rem] max-[535px]:px-0">
           <div className="flex items-center gap-[3rem] max-[535px]:justify-between max-[535px]:gap-[1.2rem]">
@@ -116,11 +116,13 @@ const AdminLayout = () => {
         </nav>
       </header>
 
-      <main className="bg-bg px-4 pt-[5rem]">
+      <main className="flex-1 bg-bg px-4 pt-[5rem]">
         <Outlet />
       </main>
 
-      <footer className="border-t border-[#eee] px-3 py-3">짤 Admin</footer>
+      <footer className="border-t border-[#eee] bg-white px-3 py-3">
+        Admin
+      </footer>
     </div>
   );
 };


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #62

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 설명                                                                                                                   
엑셀 다운로드 버튼 클릭 시 화면에 로드된 일부 목록이 아니라 `/api/orders/all` API를 호출하도록 변경했습니다.                      
다운로드 요청에 현재 주문 목록 필터 조건을 그대로 전달하도록 반영했습니다.                                                                                                                                                                      
관리자 주문 목록 / 사용자 주문 목록 페이지 모두 동일하게 적용했습니다.                                                            
상태값(`orderStatus`)만 선택된 경우도 필터 다운로드로 인식하도록 처리했습니다.                                                    
                                                                                                                                      
## 기대 효과                                                                                                                        
  - 무한스크롤로 아직 내려받지 않은 주문도 엑셀에 누락되지 않습니다.                                                                  

## 참고
  - 기존에는 `sourceOrders` 기준으로 엑셀을 생성해서 현재 화면에 적재된 데이터만 다운로드될 수 있었습니다.
  - 타입 체크(`pnpm exec tsc --noEmit`)는 실행 요청 중 사용자 중단으로 완료하지 못했습니다.


## 📷 Screenshots or Video


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order export now respects and applies all active filters to the exported data set.

* **Bug Fixes**
  * Improved error handling for export failures with user-friendly messaging.

* **Style**
  * Enhanced admin layout with improved flex column layout and updated footer styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->